### PR TITLE
Migrate to cats, migrate schema validator to networknt one, remove java.net.URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Second working method is `lookupSchema`, receiving Schema key as String or direc
 this method traverse all configured repositories trying to find Schema by its key.
 
 ```scala
-import scalaz.ValidationNel
+import cats.data.ValidatedNel
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.core.report.ProcessingMessage
 import com.snowplowanalytics.iglu.client.{ Resolver, SchemaKey }
 
 val resolverConfig: JsonNode = ???
-val schema: ValidationNel[ProcessingMessage, JsonNode] = for {
+val schema: ValidatedNel[ProcessingMessage, JsonNode] = for {
   schemaKey <- SchemaKey.parseNel("iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-0")
   resolver <- Resolver.parse(resolverConfig)
   schema <- resolver.lookupSchema(schemaKey)
@@ -42,8 +42,8 @@ val schema: ValidationNel[ProcessingMessage, JsonNode] = for {
 ```
 
 Above snippet returns mobile context JSON Schema if you provide correct `resolverConfig`.
-If not you will get all errors (like invalid format, network failure, etc) accumulated in `scalaz.NonEmptyList`,
-which itself is left side of `scalaz.ValidationNel`, structure isomorphic to native Scala `Either`.
+If not you will get all errors (like invalid format, network failure, etc) accumulated in `cats.data.NonEmptyList`,
+which itself is left side of `ValidatedNel`, structure isomorphic to native Scala `Either`.
 
 ## Find out more
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ this method traverse all configured repositories trying to find Schema by its ke
 ```scala
 import cats.data.ValidatedNel
 import com.fasterxml.jackson.databind.JsonNode
-import com.github.fge.jsonschema.core.report.ProcessingMessage
 import com.snowplowanalytics.iglu.client.{ Resolver, SchemaKey }
+import com.snowplowanalytics.iglu.client.validation.ProcessingMessage
 
 val resolverConfig: JsonNode = ???
 val schema: ValidatedNel[ProcessingMessage, JsonNode] = for {

--- a/build.sbt
+++ b/build.sbt
@@ -27,13 +27,13 @@ lazy val root = (project in file("."))
       Dependencies.Libraries.jacksonDatabind,
       Dependencies.Libraries.jsonValidator,
       // Scala
+      Dependencies.Libraries.circeParser,
       Dependencies.Libraries.json4sJackson,
-      Dependencies.Libraries.json4sScalaz,
-      Dependencies.Libraries.scalaz7,
       Dependencies.Libraries.collUtils,
       // Scala (test only)
       Dependencies.Libraries.specs2,
-      Dependencies.Libraries.scalazSpecs2,
+      Dependencies.Libraries.specs2Cats,
+      Dependencies.Libraries.specs2Mock,
       Dependencies.Libraries.mockito
     ),
     scalafmtOnCompile := true

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@
 lazy val root = (project in file("."))
   .settings(
     name := "iglu-scala-client",
-    version := "0.5.0",
+    version := "0.6.0",
     description := "Scala client and resolver for Iglu schema repositories"
   )
   .settings(BuildSettings.buildSettings)
@@ -30,6 +30,7 @@ lazy val root = (project in file("."))
       Dependencies.Libraries.circeParser,
       Dependencies.Libraries.json4sJackson,
       Dependencies.Libraries.collUtils,
+      Dependencies.Libraries.scalaj,
       // Scala (test only)
       Dependencies.Libraries.specs2,
       Dependencies.Libraries.specs2Cats,

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -26,6 +26,7 @@ object BuildSettings {
     scalaVersion  := "2.11.12",
     crossScalaVersions  := Seq("2.11.12"),
     scalacOptions := Seq(
+      "-Ypartial-unification",
       "-deprecation",
       "-encoding", "UTF-8",
       "-feature",
@@ -35,12 +36,8 @@ object BuildSettings {
       "-Ywarn-nullary-override",
       "-Ywarn-nullary-unit",
       "-Ywarn-numeric-widen",
-      "-Ywarn-value-discard",
-      "-Ypartial-unification"
+      "-Ywarn-value-discard"
     ),
-
-    scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Xfatal-warnings")),
-    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
 
     parallelExecution in Test := false // possible race bugs
   )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -35,7 +35,8 @@ object BuildSettings {
       "-Ywarn-nullary-override",
       "-Ywarn-nullary-unit",
       "-Ywarn-numeric-widen",
-      "-Ywarn-value-discard"
+      "-Ywarn-value-discard",
+      "-Ypartial-unification"
     ),
 
     scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Xfatal-warnings")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
     val circe           = "0.9.3"
     val json4s          = "3.2.11"
     val collUtils       = "6.20.0"
+    val scalaj          = "2.4.1"
     // Scala (test only)
     val specs2          = "4.3.3"
     val mockito         = "1.10.19"
@@ -36,6 +37,7 @@ object Dependencies {
     val circeParser      = "io.circe"                   %% "circe-parser"            % V.circe
     val json4sJackson    = "org.json4s"                 %% "json4s-jackson"          % V.json4s
     val collUtils        = "com.twitter"                %% "util-collection"         % V.collUtils
+    val scalaj           = "org.scalaj"                 %% "scalaj-http"             % V.scalaj
     // Scala (test only)
     val specs2           = "org.specs2"                 %% "specs2-core"             % V.specs2          % "test"
     val specs2Cats       = "org.specs2"                 %% "specs2-cats"             % V.specs2          % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     // Java
     val commonsLang     = "3.1"
     val jacksonDatabind = "2.2.3"
-    val jsonValidator   = "2.2.3"
+    val jsonValidator   = "0.1.21"
     // Scala
     val circe           = "0.9.3"
     val json4s          = "3.2.11"
@@ -31,7 +31,7 @@ object Dependencies {
     // Java
     val commonsLang      = "org.apache.commons"         %  "commons-lang3"           % V.commonsLang
     val jacksonDatabind  = "com.fasterxml.jackson.core" %  "jackson-databind"        % V.jacksonDatabind
-    val jsonValidator    = "com.github.fge"             %  "json-schema-validator"   % V.jsonValidator
+    val jsonValidator    = "com.networknt"              %  "json-schema-validator"   % V.jsonValidator
     // Scala
     val circeParser      = "io.circe"                   %% "circe-parser"            % V.circe
     val json4sJackson    = "org.json4s"                 %% "json4s-jackson"          % V.json4s

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,12 +19,11 @@ object Dependencies {
     val jacksonDatabind = "2.2.3"
     val jsonValidator   = "2.2.3"
     // Scala
+    val circe           = "0.9.3"
     val json4s          = "3.2.11"
-    val scalaz7         = "7.0.9"
     val collUtils       = "6.20.0"
     // Scala (test only)
     val specs2          = "4.3.3"
-    val scalazSpecs2    = "0.2"
     val mockito         = "1.10.19"
   }
 
@@ -34,13 +33,13 @@ object Dependencies {
     val jacksonDatabind  = "com.fasterxml.jackson.core" %  "jackson-databind"        % V.jacksonDatabind
     val jsonValidator    = "com.github.fge"             %  "json-schema-validator"   % V.jsonValidator
     // Scala
+    val circeParser      = "io.circe"                   %% "circe-parser"            % V.circe
     val json4sJackson    = "org.json4s"                 %% "json4s-jackson"          % V.json4s
-    val json4sScalaz     = "org.json4s"                 %% "json4s-scalaz"           % V.json4s
-    val scalaz7          = "org.scalaz"                 %% "scalaz-core"             % V.scalaz7
     val collUtils        = "com.twitter"                %% "util-collection"         % V.collUtils
     // Scala (test only)
     val specs2           = "org.specs2"                 %% "specs2-core"             % V.specs2          % "test"
-    val scalazSpecs2     = "org.typelevel"              %% "scalaz-specs2"           % V.scalazSpecs2    % "test"
+    val specs2Cats       = "org.specs2"                 %% "specs2-cats"             % V.specs2          % "test"
+    val specs2Mock       = "org.specs2"                 %% "specs2-mock"             % V.specs2          % "test"
     val mockito          = "org.mockito"                % "mockito-core"             % V.mockito         % "test"
   }
 }

--- a/src/main/resources/v4metaschema.json
+++ b/src/main/resources/v4metaschema.json
@@ -1,0 +1,149 @@
+{
+  "id": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Core schema meta-schema",
+  "definitions": {
+    "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#" }
+    },
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "positiveIntegerDefault0": {
+      "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+    },
+    "simpleTypes": {
+      "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": {},
+    "multipleOf": {
+      "type": "number",
+      "minimum": 0,
+      "exclusiveMinimum": true
+    },
+    "maximum": {
+      "type": "number"
+    },
+    "exclusiveMaximum": {
+      "type": "boolean",
+      "default": false
+    },
+    "minimum": {
+      "type": "number"
+    },
+    "exclusiveMinimum": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxLength": { "$ref": "#/definitions/positiveInteger" },
+    "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+    "pattern": {
+      "type": "string",
+      "format": "regex"
+    },
+    "additionalItems": {
+      "anyOf": [
+        { "type": "boolean" },
+        { "$ref": "#" }
+      ],
+      "default": {}
+    },
+    "items": {
+      "anyOf": [
+        { "$ref": "#" },
+        { "$ref": "#/definitions/schemaArray" }
+      ],
+      "default": {}
+    },
+    "maxItems": { "$ref": "#/definitions/positiveInteger" },
+    "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+    "uniqueItems": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+    "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+    "required": { "$ref": "#/definitions/stringArray" },
+    "additionalProperties": {
+      "anyOf": [
+        { "type": "boolean" },
+        { "$ref": "#" }
+      ],
+      "default": {}
+    },
+    "definitions": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#" },
+      "default": {}
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#" },
+      "default": {}
+    },
+    "patternProperties": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#" },
+      "default": {}
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          { "$ref": "#" },
+          { "$ref": "#/definitions/stringArray" }
+        ]
+      }
+    },
+    "enum": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "type": {
+      "anyOf": [
+        { "$ref": "#/definitions/simpleTypes" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/simpleTypes" },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    },
+    "format": { "type": "string" },
+    "allOf": { "$ref": "#/definitions/schemaArray" },
+    "anyOf": { "$ref": "#/definitions/schemaArray" },
+    "oneOf": { "$ref": "#/definitions/schemaArray" },
+    "not": { "$ref": "#" }
+  },
+  "dependencies": {
+    "exclusiveMaximum": [ "maximum" ],
+    "exclusiveMinimum": [ "minimum" ]
+  },
+  "default": {}
+}

--- a/src/main/scala/com.snowplowanalytics.iglu/client/Resolver.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/Resolver.scala
@@ -16,7 +16,6 @@ package com.snowplowanalytics.iglu.client
 import com.fasterxml.jackson.databind.JsonNode
 
 // JSON Schema
-import com.github.fge.jsonschema.core.report.{LogLevel, ProcessingMessage}
 
 // Scala
 import scala.annotation.tailrec
@@ -36,9 +35,9 @@ import org.json4s.jackson.JsonMethods._
 import repositories.{EmbeddedRepositoryRef, HttpRepositoryRef, RepositoryRef}
 import validation.SchemaValidation.{getErrors, isValid}
 import validation.ValidatableJsonMethods
-import validation.ProcessingMessageMethods
-import ProcessingMessageMethods._
 import utils.TemporaryJson4sCatsUtils._
+import validation.ProcessingMessage
+import validation.ProcessingMessageMethods._
 
 /**
  * Companion object. Lets us create a Resolver from
@@ -263,10 +262,10 @@ object Resolver {
       prioritizeRepos(schemaKey, tried.keys.toList).reverse // TODO: remove this legacy order, pre-0.4.0 errors were queued LIFO
         .map(repo => s"${repo.config.name} [${repo.descriptor}]")
 
-    val notFound = new ProcessingMessage()
-      .setLogLevel(LogLevel.ERROR)
-      .setMessage(s"Could not find schema with key $schemaKey in any repository, tried:")
-      .put("repositories", asJsonNode(repos))
+    val notFound = ProcessingMessage(
+      message = s"Could not find schema with key $schemaKey in any repository, tried:",
+      repositories = Some(asJsonNode(repos))
+    )
 
     NonEmptyList(notFound, failures)
   }

--- a/src/main/scala/com.snowplowanalytics.iglu/client/Resolver.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/Resolver.scala
@@ -21,8 +21,17 @@ import com.fasterxml.jackson.databind.JsonNode
 import scala.annotation.tailrec
 
 // Cats
-import cats._
-import cats.implicits._
+import cats.Semigroup
+import cats.instances.list._
+import cats.instances.set._
+import cats.instances.map._
+import cats.instances.option._
+import cats.syntax.apply._
+import cats.syntax.applicativeError._
+import cats.syntax.semigroup._
+import cats.syntax.option._
+import cats.syntax.traverse._
+import cats.syntax.validated._
 import cats.data.NonEmptyList
 import cats.data.Validated._
 

--- a/src/main/scala/com.snowplowanalytics.iglu/client/SchemaCriterion.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/SchemaCriterion.scala
@@ -12,9 +12,9 @@
  */
 package com.snowplowanalytics.iglu.client
 
-// Scalaz
-import scalaz._
-import Scalaz._
+// Cats
+import cats._
+import cats.implicits._
 
 // This project
 import validation.ProcessingMessageMethods._
@@ -40,21 +40,21 @@ object SchemaCriterion {
    * @return a Validation-boxed SchemaCriterion for
    *         Success, and an error String on Failure
    */
-  def parse(schemaCriterion: String): Validated[SchemaCriterion] = schemaCriterion match {
+  def parse(schemaCriterion: String): ValidatedType[SchemaCriterion] = schemaCriterion match {
     case SchemaCriterionRegex(vnd, n, f, mod, "*", add) if add == "*" =>
-      SchemaCriterion(vnd, n, f, mod.toInt, None, None).success
+      SchemaCriterion(vnd, n, f, mod.toInt, None, None).valid
     case SchemaCriterionRegex(vnd, n, f, mod, "*", add) =>
-      SchemaCriterion(vnd, n, f, mod.toInt, None, add.toInt.some).success
+      SchemaCriterion(vnd, n, f, mod.toInt, None, add.toInt.some).valid
     case SchemaCriterionRegex(vnd, n, f, mod, rev, "*") =>
-      SchemaCriterion(vnd, n, f, mod.toInt, rev.toInt.some, None).success
+      SchemaCriterion(vnd, n, f, mod.toInt, rev.toInt.some, None).valid
     case SchemaCriterionRegex(vnd, n, f, mod, rev, add) =>
-      SchemaCriterion(vnd, n, f, mod.toInt, rev.toInt.some, add.toInt.some).success
+      SchemaCriterion(vnd, n, f, mod.toInt, rev.toInt.some, add.toInt.some).valid
     case _ =>
-      s"$schemaCriterion is not a valid Iglu-format schema criterion".toProcessingMessage.failure
+      s"$schemaCriterion is not a valid Iglu-format schema criterion".toProcessingMessage.invalid
   }
 
-  def parseNel(schemaCriterion: String): ValidatedNel[SchemaCriterion] =
-    parse(schemaCriterion).toValidationNel
+  def parseNel(schemaCriterion: String): ValidatedNelType[SchemaCriterion] =
+    parse(schemaCriterion).toValidatedNel
 
   /**
    * Constructs an exhaustive SchemaCriterion.

--- a/src/main/scala/com.snowplowanalytics.iglu/client/SchemaCriterion.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/SchemaCriterion.scala
@@ -16,7 +16,6 @@ package com.snowplowanalytics.iglu.client
 import cats._
 import cats.implicits._
 
-// This project
 import validation.ProcessingMessageMethods._
 
 /**

--- a/src/main/scala/com.snowplowanalytics.iglu/client/SchemaCriterion.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/SchemaCriterion.scala
@@ -13,9 +13,10 @@
 package com.snowplowanalytics.iglu.client
 
 // Cats
-import cats._
-import cats.implicits._
+import cats.syntax.option._
+import cats.syntax.validated._
 
+// This project
 import validation.ProcessingMessageMethods._
 
 /**

--- a/src/main/scala/com.snowplowanalytics.iglu/client/SchemaKey.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/SchemaKey.scala
@@ -16,8 +16,8 @@ package com.snowplowanalytics.iglu.client
 import com.fasterxml.jackson.databind.JsonNode
 
 // Cats
-import cats._
-import cats.implicits._
+import cats.syntax.option._
+import cats.syntax.validated._
 
 // json4s
 import org.json4s._

--- a/src/main/scala/com.snowplowanalytics.iglu/client/SchemaKey.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/SchemaKey.scala
@@ -15,9 +15,9 @@ package com.snowplowanalytics.iglu.client
 // Jackson
 import com.fasterxml.jackson.databind.JsonNode
 
-// Scalaz
-import scalaz._
-import Scalaz._
+// Cats
+import cats._
+import cats.implicits._
 
 // json4s
 import org.json4s._
@@ -49,14 +49,14 @@ object SchemaKey {
    * @return a Validation-boxed SchemaKey for
    *         Success, and an error String on Failure
    */
-  def parse(schemaUri: String): Validated[SchemaKey] = schemaUri match {
+  def parse(schemaUri: String): ValidatedType[SchemaKey] = schemaUri match {
     case SchemaUriRegex(vnd, n, f, ver) =>
-      SchemaKey(vnd, n, f, ver).success
+      SchemaKey(vnd, n, f, ver).valid
     case _ =>
-      s"${schemaUri} is not a valid Iglu-format schema URI".toProcessingMessage.failure
+      s"${schemaUri} is not a valid Iglu-format schema URI".toProcessingMessage.invalid
   }
 
-  def parseNel(schemaUri: String): ValidatedNel[SchemaKey] = parse(schemaUri).toValidationNel
+  def parseNel(schemaUri: String): ValidatedNelType[SchemaKey] = parse(schemaUri).toValidatedNel
 }
 
 /**

--- a/src/main/scala/com.snowplowanalytics.iglu/client/repositories/EmbeddedRepositoryRef.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/repositories/EmbeddedRepositoryRef.scala
@@ -22,8 +22,12 @@ import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonNode
 
 // Cats
-import cats._
-import cats.implicits._
+import cats.instances.option._
+import cats.instances.either._
+import cats.syntax.apply._
+import cats.syntax.validated._
+import cats.syntax.either._
+import cats.syntax.traverse._
 
 // json4s
 import org.json4s._
@@ -137,8 +141,7 @@ case class EmbeddedRepositoryRef(override val config: RepositoryRefConfig, path:
 
     try {
       streamOpt
-        .map(stream => new ObjectMapper().readTree(stream).asRight[ProcessingMessage]) // TODO: sequence on Validated doesn't work
-        .sequence
+        .traverse(stream => new ObjectMapper().readTree(stream).asRight[ProcessingMessage])
         .toValidated
     } catch {
       case jpe: JsonParseException => // Child of IOException so match first

--- a/src/main/scala/com.snowplowanalytics.iglu/client/repositories/HttpRepositoryRef.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/repositories/HttpRepositoryRef.scala
@@ -21,14 +21,13 @@ import java.net.{MalformedURLException, URL, UnknownHostException}
 import org.apache.commons.lang3.exception.ExceptionUtils
 
 // Jackson
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonNode
 
-// Json Schema
-import com.github.fge.jackson.JsonNodeReader
-
 // Scala
 import scala.util.control.NonFatal
+import scala.io.Source
 
 // Scalaz
 import cats._
@@ -51,8 +50,6 @@ object HttpRepositoryRef {
 
   implicit val formats = DefaultFormats
 
-  private lazy val reader = new JsonNodeReader()
-
   /**
    * Helper class to extract HTTP URI and api key from config JSON
    */
@@ -73,7 +70,8 @@ object HttpRepositoryRef {
       case Some(key) => connection.setRequestProperty("apikey", key)
       case None      => ()
     }
-    reader.fromInputStream(connection.getInputStream)
+
+    new ObjectMapper().readTree(connection.getInputStream)
   }
 
   /**

--- a/src/main/scala/com.snowplowanalytics.iglu/client/repositories/RepositoryRef.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/repositories/RepositoryRef.scala
@@ -17,10 +17,8 @@ package repositories
 import com.fasterxml.jackson.databind.JsonNode
 
 // Cats
-import cats._
-import cats.implicits._
-import cats.data._
-import cats.data.Validated._
+import cats.syntax.apply._
+import cats.data.Validated.{Invalid, Valid}
 
 // json4s
 import org.json4s._

--- a/src/main/scala/com.snowplowanalytics.iglu/client/repositories/RepositoryRef.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/repositories/RepositoryRef.scala
@@ -16,9 +16,6 @@ package repositories
 // Jackson
 import com.fasterxml.jackson.databind.JsonNode
 
-// JSON Schema
-import com.github.fge.jsonschema.core.report.ProcessingMessage
-
 // Cats
 import cats._
 import cats.implicits._
@@ -33,6 +30,7 @@ import org.json4s.jackson.JsonMethods._
 // This project
 import validation.ProcessingMessageMethods._
 import utils.TemporaryJson4sCatsUtils._
+import validation.ProcessingMessage
 
 /**
  * Singleton object contains a constructor

--- a/src/main/scala/com.snowplowanalytics.iglu/client/utils/TemporaryJson4sCatsUtils.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/utils/TemporaryJson4sCatsUtils.scala
@@ -8,7 +8,7 @@ import cats.data.{Validated, ValidatedNel}
 import org.json4s.JsonAST.{JNothing, JObject, JValue}
 import org.json4s.{Formats, Reader}
 
-// Just ignore this in the review, these functions are temporary
+// Just ignore this in the review, these functions are temporary (will be gone in the next PR)
 object TemporaryJson4sCatsUtils {
 
   def validatedField[A: Manifest](name: String)(json: JValue)(

--- a/src/main/scala/com.snowplowanalytics.iglu/client/utils/TemporaryJson4sCatsUtils.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/utils/TemporaryJson4sCatsUtils.scala
@@ -1,10 +1,9 @@
 package com.snowplowanalytics.iglu.client.utils
 
-import cats._
-import cats.implicits._
-import cats.data.Validated.Valid
-
+import cats.syntax.option._
+import cats.syntax.validated._
 import cats.data.{Validated, ValidatedNel}
+
 import org.json4s.JsonAST.{JNothing, JObject, JValue}
 import org.json4s.{Formats, Reader}
 

--- a/src/main/scala/com.snowplowanalytics.iglu/client/utils/TemporaryJson4sCatsUtils.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/utils/TemporaryJson4sCatsUtils.scala
@@ -1,0 +1,35 @@
+package com.snowplowanalytics.iglu.client.utils
+
+import cats._
+import cats.implicits._
+import cats.data.Validated.Valid
+
+import cats.data.{Validated, ValidatedNel}
+import org.json4s.JsonAST.{JNothing, JObject, JValue}
+import org.json4s.{Formats, Reader}
+
+// Just ignore this in the review, these functions are temporary
+object TemporaryJson4sCatsUtils {
+
+  def validatedField[A: Manifest](name: String)(json: JValue)(
+    implicit formats: Formats): ValidatedNel[Throwable, A] =
+    json match {
+      case JObject(fs) =>
+        fs.find(_._1 == name)
+          .map(f => f._2.extract[A].valid)
+          .getOrElse(Validated.invalidNel(new RuntimeException(s"$name: $json")))
+      case x =>
+        Validated.invalidNel(new RuntimeException("failed"))
+    }
+
+  def validatedOptionalField[A: Manifest](name: String)(json: JValue)(
+    implicit formats: Formats): ValidatedNel[Throwable, Option[A]] =
+    json match {
+      case JObject(fs) =>
+        fs.find(_._1 == name)
+          .map(f => f._2.extract[A].some.validNel[Throwable])
+          .getOrElse(None.validNel[Throwable])
+      case x =>
+        Validated.invalidNel(new RuntimeException("failed"))
+    }
+}

--- a/src/main/scala/com.snowplowanalytics.iglu/client/validation/Validatable.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/validation/Validatable.scala
@@ -39,7 +39,7 @@ trait Validatable[JsonAST] { self =>
    *         ProcessingMessages
    */
   def validateAgainstSchema(instance: JsonAST, schema: JsonAST)(
-    implicit resolver: Resolver): ValidatedNel[JsonAST]
+    implicit resolver: Resolver): ValidatedNelType[JsonAST]
 
   /**
    * Validates a self-describing JSON against
@@ -59,7 +59,7 @@ trait Validatable[JsonAST] { self =>
    *         of ProcessingMessages
    */
   def validate(instance: JsonAST, dataOnly: Boolean = false)(
-    implicit resolver: Resolver): ValidatedNel[JsonAST]
+    implicit resolver: Resolver): ValidatedNelType[JsonAST]
 
   /**
    * The same as validate(), but on Success returns
@@ -81,7 +81,7 @@ trait Validatable[JsonAST] { self =>
    *         of ProcessingMessages
    */
   def validateAndIdentifySchema(instance: JsonAST, dataOnly: Boolean = false)(
-    implicit resolver: Resolver): ValidatedNel[(SchemaKey, JsonAST)]
+    implicit resolver: Resolver): ValidatedNelType[(SchemaKey, JsonAST)]
 
   /**
    * Verify that this JSON is of the expected schema,
@@ -105,7 +105,7 @@ trait Validatable[JsonAST] { self =>
   def verifySchemaAndValidate(
     instance: JsonAST,
     schemaCriterion: SchemaCriterion,
-    dataOnly: Boolean = false)(implicit resolver: Resolver): ValidatedNel[JsonAST]
+    dataOnly: Boolean = false)(implicit resolver: Resolver): ValidatedNelType[JsonAST]
 
   /**
    * Operations available as postfix-ops
@@ -124,7 +124,8 @@ trait Validatable[JsonAST] { self =>
      * @return either Success boxing the JsonNode, or a Failure boxing
      *         a NonEmptyList of ProcessingMessages
      */
-    def validateAgainstSchema(schema: JsonAST)(implicit resolver: Resolver): ValidatedNel[JsonAST] =
+    def validateAgainstSchema(schema: JsonAST)(
+      implicit resolver: Resolver): ValidatedNelType[JsonAST] =
       self.validateAgainstSchema(instance, schema)
 
     /**
@@ -135,7 +136,7 @@ trait Validatable[JsonAST] { self =>
      * @return either Success boxing the JsonNode or a Failure boxing a NonEmptyList
      *         of ProcessingMessages
      */
-    def validate(dataOnly: Boolean)(implicit resolver: Resolver): ValidatedNel[JsonAST] =
+    def validate(dataOnly: Boolean)(implicit resolver: Resolver): ValidatedNelType[JsonAST] =
       self.validate(instance, dataOnly)
 
     /**
@@ -148,7 +149,7 @@ trait Validatable[JsonAST] { self =>
      *         or a Failure boxing a NonEmptyList of ProcessingMessages
      */
     def validateAndIdentifySchema(dataOnly: Boolean)(
-      implicit resolver: Resolver): ValidatedNel[(SchemaKey, JsonAST)] =
+      implicit resolver: Resolver): ValidatedNelType[(SchemaKey, JsonAST)] =
       self.validateAndIdentifySchema(instance, dataOnly)
 
     /**
@@ -161,7 +162,7 @@ trait Validatable[JsonAST] { self =>
      *         of ProcessingMessages
      */
     def verifySchemaAndValidate(schemaCriterion: SchemaCriterion, dataOnly: Boolean)(
-      implicit resolver: Resolver): ValidatedNel[JsonAST] =
+      implicit resolver: Resolver): ValidatedNelType[JsonAST] =
       self.verifySchemaAndValidate(instance, schemaCriterion, dataOnly)
   }
 }

--- a/src/main/scala/com.snowplowanalytics.iglu/client/validation/Validatable.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/validation/Validatable.scala
@@ -38,8 +38,7 @@ trait Validatable[JsonAST] { self =>
    *         a NonEmptyList of
    *         ProcessingMessages
    */
-  def validateAgainstSchema(instance: JsonAST, schema: JsonAST)(
-    implicit resolver: Resolver): ValidatedNelType[JsonAST]
+  def validateAgainstSchema(instance: JsonAST, schema: JsonAST): ValidatedNelType[JsonAST]
 
   /**
    * Validates a self-describing JSON against

--- a/src/main/scala/com.snowplowanalytics.iglu/client/validation/ValidatableJValue.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/validation/ValidatableJValue.scala
@@ -19,8 +19,7 @@ import org.json4s.jackson.JsonMethods.{asJsonNode, fromJsonNode}
 
 object ValidatableJValue extends Validatable[JValue] {
 
-  def validateAgainstSchema(instance: JValue, schema: JValue)(
-    implicit resolver: Resolver): ValidatedNelType[JValue] =
+  def validateAgainstSchema(instance: JValue, schema: JValue): ValidatedNelType[JValue] =
     ValidatableJsonMethods
       .validateAgainstSchema(asJsonNode(instance), asJsonNode(schema))
       .map(fromJsonNode)

--- a/src/main/scala/com.snowplowanalytics.iglu/client/validation/ValidatableJValue.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/validation/ValidatableJValue.scala
@@ -20,17 +20,17 @@ import org.json4s.jackson.JsonMethods.{asJsonNode, fromJsonNode}
 object ValidatableJValue extends Validatable[JValue] {
 
   def validateAgainstSchema(instance: JValue, schema: JValue)(
-    implicit resolver: Resolver): ValidatedNel[JValue] =
+    implicit resolver: Resolver): ValidatedNelType[JValue] =
     ValidatableJsonMethods
       .validateAgainstSchema(asJsonNode(instance), asJsonNode(schema))
       .map(fromJsonNode)
 
   def validate(instance: JValue, dataOnly: Boolean = false)(
-    implicit resolver: Resolver): ValidatedNel[JValue] =
+    implicit resolver: Resolver): ValidatedNelType[JValue] =
     ValidatableJsonMethods.validate(asJsonNode(instance), dataOnly)(resolver).map(fromJsonNode)
 
   def validateAndIdentifySchema(instance: JValue, dataOnly: Boolean = false)(
-    implicit resolver: Resolver): ValidatedNel[(SchemaKey, JValue)] = {
+    implicit resolver: Resolver): ValidatedNelType[(SchemaKey, JValue)] = {
     ValidatableJsonMethods.validateAndIdentifySchema(asJsonNode(instance), dataOnly)(resolver).map {
       case (key, json) =>
         (key, fromJsonNode(json))
@@ -38,7 +38,7 @@ object ValidatableJValue extends Validatable[JValue] {
   }
 
   def verifySchemaAndValidate(json: JValue, schemaCriterion: SchemaCriterion, dataOnly: Boolean)(
-    implicit resolver: Resolver): ValidatedNel[JValue] =
+    implicit resolver: Resolver): ValidatedNelType[JValue] =
     ValidatableJsonMethods
       .verifySchemaAndValidate(asJsonNode(json), schemaCriterion, dataOnly)(resolver)
       .map(fromJsonNode)

--- a/src/main/scala/com.snowplowanalytics.iglu/client/validation/ValidatableJsonMethods.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/validation/ValidatableJsonMethods.scala
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.networknt.schema._
 
 // Cats
-import cats._
-import cats.implicits._
+import cats.syntax.either._
+import cats.syntax.validated._
 import cats.data.NonEmptyList
 
 // This project

--- a/src/main/scala/com.snowplowanalytics.iglu/client/validation/processingMessages.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/validation/processingMessages.scala
@@ -17,7 +17,6 @@ package validation
 import com.fasterxml.jackson.databind.JsonNode
 
 // Cats
-import cats.implicits._
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 // Circe

--- a/src/main/scala/com.snowplowanalytics.iglu/package.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/package.scala
@@ -19,8 +19,9 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.core.report.ProcessingMessage
 
 // Scalaz
-import scalaz._
-import Scalaz._
+import cats._
+import cats.implicits._
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 // LRU
 import com.twitter.util.SynchronizedLruMap
@@ -41,8 +42,8 @@ package object client {
   /**
    * Helpful archetypes
    */
-  type Validated[A]    = Validation[ProcessingMessage, A]
-  type ValidatedNel[A] = ValidationNel[ProcessingMessage, A]
+  type ValidatedType[A]    = Validated[ProcessingMessage, A]
+  type ValidatedNelType[A] = ValidatedNel[ProcessingMessage, A]
 
   /**
    * Our LRU cache of schemas
@@ -68,7 +69,7 @@ package object client {
    * JsonNode in case of Success or Map of all currently failed repositories
    * in case of Failure
    */
-  type SchemaLookup = Validation[RepoFailuresMap, JsonNode]
+  type SchemaLookup = Validated[RepoFailuresMap, JsonNode]
 
   /**
    * Schema lookup result associated with timestamp (in seconds) it was stored at

--- a/src/main/scala/com.snowplowanalytics.iglu/package.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/package.scala
@@ -16,8 +16,6 @@ package com.snowplowanalytics.iglu
 import com.fasterxml.jackson.databind.JsonNode
 
 // Cats
-import cats._
-import cats.implicits._
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 // LRU

--- a/src/main/scala/com.snowplowanalytics.iglu/package.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/package.scala
@@ -15,10 +15,7 @@ package com.snowplowanalytics.iglu
 // Jackson
 import com.fasterxml.jackson.databind.JsonNode
 
-// JSON Schema Validator
-import com.github.fge.jsonschema.core.report.ProcessingMessage
-
-// Scalaz
+// Cats
 import cats._
 import cats.implicits._
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
@@ -29,6 +26,7 @@ import com.twitter.util.SynchronizedLruMap
 // This project
 import client.repositories.RepositoryRef
 import client.Resolver.RepoError
+import client.validation.ProcessingMessage
 
 /**
  * Scala package object to hold types,

--- a/src/test/resources/raw-jsonschema/beer-schema.json
+++ b/src/test/resources/raw-jsonschema/beer-schema.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Simple schema for testing ValidatableJsonNode",
   "type": "object",
   "properties": {

--- a/src/test/resources/raw-jsonschema/beer-schema.json
+++ b/src/test/resources/raw-jsonschema/beer-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/schema#",
   "description": "Simple schema for testing ValidatableJsonNode",
   "type": "object",
   "properties": {

--- a/src/test/scala/com.snowplowanalytics.iglu.client/ResolverSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/ResolverSpec.scala
@@ -13,8 +13,8 @@
 package com.snowplowanalytics.iglu.client
 
 // Cats
-import cats._
-import cats.implicits._
+import cats.syntax.option._
+import cats.syntax.validated._
 import cats.data.NonEmptyList
 
 // json4s

--- a/src/test/scala/com.snowplowanalytics.iglu.client/SchemaCriterionSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/SchemaCriterionSpec.scala
@@ -12,10 +12,6 @@
  */
 package com.snowplowanalytics.iglu.client
 
-// Cats
-import cats._
-import cats.implicits._
-
 // Specs2
 import org.specs2.Specification
 import org.specs2.matcher.{DataTables, ValidatedMatchers}

--- a/src/test/scala/com.snowplowanalytics.iglu.client/SchemaCriterionSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/SchemaCriterionSpec.scala
@@ -11,7 +11,6 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 package com.snowplowanalytics.iglu.client
-package validation
 
 // Cats
 import cats._

--- a/src/test/scala/com.snowplowanalytics.iglu.client/SchemaCriterionSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/SchemaCriterionSpec.scala
@@ -13,16 +13,15 @@
 package com.snowplowanalytics.iglu.client
 package validation
 
-// Scalaz
-import scalaz._
-import Scalaz._
+// Cats
+import cats._
+import cats.implicits._
 
 // Specs2
 import org.specs2.Specification
-import org.specs2.matcher.DataTables
-import org.specs2.scalaz.ValidationMatchers
+import org.specs2.matcher.{DataTables, ValidatedMatchers}
 
-class SchemaCriterionSpec extends Specification with DataTables with ValidationMatchers {
+class SchemaCriterionSpec extends Specification with DataTables with ValidatedMatchers {
   def is = s2"""
 
   This is a specification to test the SchemaCriterion class
@@ -66,7 +65,7 @@ class SchemaCriterionSpec extends Specification with DataTables with ValidationM
   def e3 = {
     val criterion =
       SchemaCriterion.parse("iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-*")
-    criterion must beSuccessful(
+    criterion must beValid(
       SchemaCriterion(
         "com.snowplowanalytics.snowplow",
         "mobile_context",
@@ -79,7 +78,7 @@ class SchemaCriterionSpec extends Specification with DataTables with ValidationM
   def e4 = {
     val criterion =
       SchemaCriterion.parse("iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-*-3")
-    criterion must beSuccessful(
+    criterion must beValid(
       SchemaCriterion(
         "com.snowplowanalytics.snowplow",
         "mobile_context",

--- a/src/test/scala/com.snowplowanalytics.iglu.client/SpecHelpers.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/SpecHelpers.scala
@@ -14,7 +14,6 @@ package com.snowplowanalytics.iglu.client
 
 // json4s
 import org.json4s._
-import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods.{parse, asJsonNode => ajn}
 
 // This project
@@ -49,9 +48,7 @@ object SpecHelpers {
     keyword: String,
     foundExpected: Option[(String, String)],
     requiredMissing: Option[(String, String)],
-    unwanted: Option[String]): ProcessingMessage = {
-
+    unwanted: Option[String]): ProcessingMessage =
     ProcessingMessage(message = message)
-  }
 
 }

--- a/src/test/scala/com.snowplowanalytics.iglu.client/SpecHelpers.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/SpecHelpers.scala
@@ -12,9 +12,6 @@
  */
 package com.snowplowanalytics.iglu.client
 
-// JSON Schema
-import com.github.fge.jsonschema.core.report.{LogLevel, ProcessingMessage}
-
 // json4s
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -22,6 +19,7 @@ import org.json4s.jackson.JsonMethods.{parse, asJsonNode => ajn}
 
 // This project
 import repositories.{EmbeddedRepositoryRef, HttpRepositoryRef, RepositoryRefConfig}
+import com.snowplowanalytics.iglu.client.validation.ProcessingMessage
 
 object SpecHelpers {
 
@@ -43,6 +41,7 @@ object SpecHelpers {
   def asJsonNode(str: String) =
     ajn(asJValue(str))
 
+  // TODO: improve this after ProcessingMessage format is discussed
   def asProcessingMessage(
     message: String,
     schema: String,
@@ -50,33 +49,9 @@ object SpecHelpers {
     keyword: String,
     foundExpected: Option[(String, String)],
     requiredMissing: Option[(String, String)],
-    unwanted: Option[String]) = {
+    unwanted: Option[String]): ProcessingMessage = {
 
-    val pm = new ProcessingMessage()
-      .setLogLevel(LogLevel.ERROR)
-      .setMessage(message)
-      .put("schema", asJsonNode(schema))
-      .put("instance", asJsonNode(instance))
-      .put("domain", "validation")
-      .put("keyword", keyword)
-
-    foundExpected match {
-      case Some(Tuple2(found, expected)) =>
-        pm.put("found", found)
-        pm.put("expected", asJsonNode(expected))
-      case _ =>
-    }
-    requiredMissing match {
-      case Some(Tuple2(required, missing)) =>
-        pm.put("required", asJsonNode(required))
-        pm.put("missing", asJsonNode(missing))
-      case _ =>
-    }
-    for (unw <- unwanted) {
-      pm.put("unwanted", asJsonNode(unw))
-    }
-
-    pm
+    ProcessingMessage(message = message)
   }
 
 }

--- a/src/test/scala/com.snowplowanalytics.iglu.client/repositories/EmbeddedRepositoryRefSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/repositories/EmbeddedRepositoryRefSpec.scala
@@ -100,10 +100,7 @@ class EmbeddedRepositoryRefSpec extends Specification with DataTables with Valid
   def e5 = {
     val schemaKey =
       SchemaKey("com.snowplowanalytics.iglu-test", "corrupted_schema", "jsonschema", "1-0-0")
-    val expected =
-      "Problem parsing /iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/corrupted_schema/jsonschema/1-0-0 as JSON in embedded Iglu repository Iglu Test Embedded: Unexpected end-of-input within/between OBJECT entries at [Source: java.io.BufferedInputStream@xxxxxx; line: 10, column: 316]".toProcessingMessage.toString
-    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey).leftMap(_.toString) must beInvalid(
-      expected.toString)
+    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey).leftMap(_.toString) must beInvalid
   }
 
 }

--- a/src/test/scala/com.snowplowanalytics.iglu.client/repositories/EmbeddedRepositoryRefSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/repositories/EmbeddedRepositoryRefSpec.scala
@@ -13,19 +13,18 @@
 package com.snowplowanalytics.iglu.client
 package repositories
 
-// Scalaz
-import scalaz._
-import Scalaz._
+// Cats
+import cats._
+import cats.implicits._
 
 // This project
 import validation.ProcessingMessageMethods._
 
 // Specs2
 import org.specs2.Specification
-import org.specs2.matcher.DataTables
-import org.specs2.scalaz.ValidationMatchers
+import org.specs2.matcher.{DataTables, ValidatedMatchers}
 
-class EmbeddedRepositoryRefSpec extends Specification with DataTables with ValidationMatchers {
+class EmbeddedRepositoryRefSpec extends Specification with DataTables with ValidatedMatchers {
   def is = s2"""
 
   This is a specification to test an embedded RepositoryRef
@@ -57,7 +56,7 @@ class EmbeddedRepositoryRefSpec extends Specification with DataTables with Valid
       config = RepositoryRefConfig("Acme Embedded", 100, List("uk.co.acme", "de.acme")),
       path = "/acme-embedded-new"
     )
-    EmbeddedRepositoryRef.parse(AcmeConfig) must beSuccessful(expected)
+    EmbeddedRepositoryRef.parse(AcmeConfig) must beValid(expected)
   }
 
   def e3 = {
@@ -89,13 +88,13 @@ class EmbeddedRepositoryRefSpec extends Specification with DataTables with Valid
         |"additionalProperties":false
       |}""".stripMargin.replaceAll("[\n\r]", "")
 
-    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey).map(_.map(_.toString)) must beSuccessful(
+    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey).map(_.map(_.toString)) must beValid(
       Some(expected))
   }
 
   def e4 = {
     val schemaKey = SchemaKey("com.acme.n-a", "null", "jsonschema", "1-0-0")
-    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey) must beSuccessful(None)
+    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey) must beValid(None)
   }
 
   def e5 = {
@@ -103,7 +102,7 @@ class EmbeddedRepositoryRefSpec extends Specification with DataTables with Valid
       SchemaKey("com.snowplowanalytics.iglu-test", "corrupted_schema", "jsonschema", "1-0-0")
     val expected =
       "Problem parsing /iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/corrupted_schema/jsonschema/1-0-0 as JSON in embedded Iglu repository Iglu Test Embedded: Unexpected end-of-input within/between OBJECT entries at [Source: java.io.BufferedInputStream@xxxxxx; line: 10, column: 316]".toProcessingMessage.toString
-    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey).leftMap(_.toString) must beFailing(
+    SpecHelpers.EmbeddedTest.lookupSchema(schemaKey).leftMap(_.toString) must beInvalid(
       expected.toString)
   }
 

--- a/src/test/scala/com.snowplowanalytics.iglu.client/repositories/EmbeddedRepositoryRefSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/repositories/EmbeddedRepositoryRefSpec.scala
@@ -13,13 +13,6 @@
 package com.snowplowanalytics.iglu.client
 package repositories
 
-// Cats
-import cats._
-import cats.implicits._
-
-// This project
-import validation.ProcessingMessageMethods._
-
 // Specs2
 import org.specs2.Specification
 import org.specs2.matcher.{DataTables, ValidatedMatchers}

--- a/src/test/scala/com.snowplowanalytics.iglu.client/repositories/HttpRepositoryRefSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/repositories/HttpRepositoryRefSpec.scala
@@ -14,8 +14,7 @@ package com.snowplowanalytics.iglu.client
 package repositories
 
 // Cats
-import cats._
-import cats.implicits._
+import cats.syntax.option._
 
 // Specs2
 import org.specs2.Specification

--- a/src/test/scala/com.snowplowanalytics.iglu.client/repositories/HttpRepositoryRefSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/repositories/HttpRepositoryRefSpec.scala
@@ -13,16 +13,15 @@
 package com.snowplowanalytics.iglu.client
 package repositories
 
-// Scalaz
-import scalaz._
-import Scalaz._
+// Cats
+import cats._
+import cats.implicits._
 
 // Specs2
 import org.specs2.Specification
-import org.specs2.matcher.DataTables
-import org.specs2.scalaz.ValidationMatchers
+import org.specs2.matcher.{DataTables, ValidatedMatchers}
 
-class HttpRepositoryRefSpec extends Specification with DataTables with ValidationMatchers {
+class HttpRepositoryRefSpec extends Specification with DataTables with ValidatedMatchers {
   def is = s2"""
 
   This is a specification to test an HTTP-based RepositoryRef
@@ -68,7 +67,7 @@ class HttpRepositoryRefSpec extends Specification with DataTables with Validatio
       config = RepositoryRefConfig("Acme Iglu Repo", 5, List("com.acme")),
       uri = "http://iglu.acme.com"
     )
-    HttpRepositoryRef.parse(AcmeConfig) must beSuccessful(expected)
+    HttpRepositoryRef.parse(AcmeConfig) must beValid(expected)
   }
 
   def e3 = {
@@ -109,12 +108,12 @@ class HttpRepositoryRefSpec extends Specification with DataTables with Validatio
     )
 
     val actual = SpecHelpers.IgluCentral.lookupSchema(schemaKey)
-    actual.map(_.map(_.toString)) must beSuccessful(expected.toString.some)
+    actual.map(_.map(_.toString)) must beValid(expected.toString.some)
   }
 
   def e4 = {
     val schemaKey = SchemaKey("de.ersatz.n-a", "null", "jsonschema", "1-0-0")
-    SpecHelpers.IgluCentral.lookupSchema(schemaKey) must beSuccessful(None)
+    SpecHelpers.IgluCentral.lookupSchema(schemaKey) must beValid(None)
   }
 
   def e5 = {
@@ -123,6 +122,6 @@ class HttpRepositoryRefSpec extends Specification with DataTables with Validatio
       uri = "http://iglu.acme.com",
       Some("de305d54-75b4-431b-adb2-eb6b9e546014")
     )
-    HttpRepositoryRef.parse(AcmeConfigWithAuth) must beSuccessful(expected)
+    HttpRepositoryRef.parse(AcmeConfigWithAuth) must beValid(expected)
   }
 }

--- a/src/test/scala/com.snowplowanalytics.iglu.client/validation/JValueValidation.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/validation/JValueValidation.scala
@@ -21,9 +21,9 @@ import ValidatableJValue._
 
 // Specs2
 import org.specs2.Specification
-import org.specs2.scalaz.ValidationMatchers
+import org.specs2.matcher.ValidatedMatchers
 
-class SchemaJValueValidationSpec extends Specification with ValidationMatchers {
+class SchemaJValueValidationSpec extends Specification with ValidatedMatchers {
   def is = s2"""
 
   This is a specification to test Schema Validation with json4s AST
@@ -42,7 +42,7 @@ class SchemaJValueValidationSpec extends Specification with ValidationMatchers {
     """{"schema": "iglu:com.snowplowanalytics.iglu-test/invalid-protocol/jsonschema/1-0-0", "data": { "id": 0 } }"""
   )
 
-  def e1 = validJson.validate(false) must beSuccessful(validJson)
+  def e1 = validJson.validate(false) must beValid(validJson)
 
-  def e2 = validJsonWithInvalidSchema.validate(false) must beFailing
+  def e2 = validJsonWithInvalidSchema.validate(false) must beInvalid
 }

--- a/src/test/scala/com.snowplowanalytics.iglu.client/validation/RawValidationSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/validation/RawValidationSpec.scala
@@ -16,16 +16,18 @@ package validation
 // Jackson
 import com.github.fge.jackson.JsonLoader
 
-// Scalaz
-import scalaz._
-import Scalaz._
+// Cats
+import cats._
+import cats.implicits._
+import cats.data.NonEmptyList
+import cats.data.Validated._
 
 // Specs2
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
-import org.specs2.scalaz.ValidationMatchers
+import org.specs2.matcher.ValidatedMatchers
 
-class RawValidationSpec extends Specification with DataTables with ValidationMatchers {
+class RawValidationSpec extends Specification with DataTables with ValidatedMatchers {
   def is = s2"""
 
   This is a specification to test the basic ValidatableJsonNode functionality
@@ -42,7 +44,7 @@ class RawValidationSpec extends Specification with DataTables with ValidationMat
 
   def e1 = {
     val json = SpecHelpers.asJsonNode("""{"country": "JP", "beers": ["Asahi", "Orion", "..."]}""")
-    json.validateAgainstSchema(SimpleSchema) must beSuccessful(json)
+    json.validateAgainstSchema(SimpleSchema) must beValid(json)
   }
 
   def e2 =
@@ -54,7 +56,7 @@ class RawValidationSpec extends Specification with DataTables with ValidationMat
       )) { str: String =>
       {
         val json = SpecHelpers.asJsonNode(str)
-        json.validateAgainstSchema(SimpleSchema) must beSuccessful(json)
+        json.validateAgainstSchema(SimpleSchema) must beValid(json)
       }
     }
 
@@ -71,7 +73,7 @@ class RawValidationSpec extends Specification with DataTables with ValidationMat
         {
           val json = SpecHelpers.asJsonNode(input)
           json.validateAgainstSchema(SimpleSchema) must beLike {
-            case Failure(NonEmptyList(head, tail @ _*)) if tail.isEmpty =>
+            case Invalid(NonEmptyList(head, tail)) if tail.isEmpty =>
               head.toString must_== SpecHelpers
                 .asProcessingMessage(
                   message,

--- a/src/test/scala/com.snowplowanalytics.iglu.client/validation/RawValidationSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/validation/RawValidationSpec.scala
@@ -13,12 +13,6 @@
 package com.snowplowanalytics.iglu.client
 package validation
 
-// Cats
-import cats._
-import cats.implicits._
-import cats.data.NonEmptyList
-import cats.data.Validated._
-
 // Specs2
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
@@ -79,6 +73,7 @@ class RawValidationSpec extends Specification with DataTables with ValidatedMatc
       (_, input, message, schema, instance, keyword, foundExpected, requiredMissing) =>
         {
           val json = SpecHelpers.asJsonNode(input)
+          json.validateAgainstSchema(simpleSchema) must beInvalid
         }
     }
 

--- a/src/test/scala/com.snowplowanalytics.iglu.client/validation/SchemaValidationSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/validation/SchemaValidationSpec.scala
@@ -21,9 +21,9 @@ import ValidatableJsonMethods._
 
 // Specs2
 import org.specs2.Specification
-import org.specs2.scalaz.ValidationMatchers
+import org.specs2.matcher.ValidatedMatchers
 
-class SchemaValidationSpec extends Specification with ValidationMatchers {
+class SchemaValidationSpec extends Specification with ValidatedMatchers {
   def is = s2"""
 
   This is a specification to test Schema Validation
@@ -46,8 +46,8 @@ class SchemaValidationSpec extends Specification with ValidationMatchers {
 
   val validJValueWithInvalidSchema = fromJsonNode(validJsonWithInvalidSchema)
 
-  def e1 = validJson.validate(false) must beSuccessful(validJson)
+  def e1 = validJson.validate(false) must beValid(validJson)
 
-  def e2 = validJsonWithInvalidSchema.validate(false) must beFailing
+  def e2 = validJsonWithInvalidSchema.validate(false) must beInvalid
 
 }

--- a/src/test/scala/com.snowplowanalytics.iglu.client/validation/SelfDescValidationSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/validation/SelfDescValidationSpec.scala
@@ -80,7 +80,10 @@ class SelfDescValidationSpec extends Specification with ValidatedMatchers {
     )
     .map(_.toString)
 
-  def e3 = invalidJson.validate(false).leftMap(_.map(_.toString)) must beInvalid(invalidExpected)
+  def e3 =
+    invalidJson
+      .validate(false)
+      .leftMap(_.map(_.toString)) must beInvalid // TODO: check expected messages
 
   val expectedKey =
     SchemaKey("com.snowplowanalytics.iglu-test", "stock-item", "jsonschema", "1-0-0")
@@ -94,8 +97,9 @@ class SelfDescValidationSpec extends Specification with ValidatedMatchers {
     validJson.validateAndIdentifySchema(true) must beValid((expectedKey, validJson.get("data")))
 
   def e6 =
-    invalidJson.validateAndIdentifySchema(false).leftMap(_.map(_.toString)) must beInvalid(
-      invalidExpected)
+    invalidJson
+      .validateAndIdentifySchema(false)
+      .leftMap(_.map(_.toString)) must beInvalid // TODO: Check expected messages
 
   def e7 = validJson.verifySchemaAndValidate(expectedCriterion, false) must beValid(validJson)
 

--- a/src/test/scala/com.snowplowanalytics.iglu.client/validation/SelfDescValidationSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/validation/SelfDescValidationSpec.scala
@@ -14,8 +14,6 @@ package com.snowplowanalytics.iglu.client
 package validation
 
 // Cats
-import cats._
-import cats.implicits._
 import cats.data.NonEmptyList
 
 // This project


### PR DESCRIPTION
I've split the work because there are a lot of lines changed  - this is the PR number 2, after the bumps.

`ValidatableJsonMethods` (Jackson) and `ValidatableJValue` (json4s) will be gone next PR, as will be `TemporaryJson4sCatsUtils`.

The networknt commit is WIP because the ProcessingMessage format is not there yet.