### PR TITLE
Ability to run blocking operations on separate thread pool

### DIFF
--- a/src/main/scala/com.snowplowanalytics.iglu/client/resolver/BlockerF.scala
+++ b/src/main/scala/com.snowplowanalytics.iglu/client/resolver/BlockerF.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.iglu.client.resolver
+
+import cats.effect.{Blocker, ContextShift}
+
+/**
+ * An execution context that is safe to use for blocking operations
+ *
+ * BlockerF is similar to a cats.effect.Blocker, except that `blockOn` does not require an implicit
+ * ContextShift; instead, the ContextShift is bound to the instance of the trait when it is
+ * constructed.
+ *
+ * This is a bit of a hack... but it allows us to define a BlockerF[Id], which is a requirement for
+ * many apps that depend this client
+ */
+trait BlockerF[F[_]] {
+
+  def blockOn[A](f: F[A]): F[A]
+
+}
+
+object BlockerF {
+
+  def ofBlocker[F[_]: ContextShift](blocker: Blocker): BlockerF[F] =
+    new BlockerF[F] {
+      override def blockOn[A](f: F[A]): F[A] =
+        blocker.blockOn(f)
+    }
+
+  def noop[F[_]]: BlockerF[F] =
+    new BlockerF[F] {
+      override def blockOn[A](f: F[A]): F[A] =
+        f
+    }
+
+}

--- a/src/test/scala/com.snowplowanalytics.iglu.client/SpecHelpers.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/SpecHelpers.scala
@@ -23,6 +23,7 @@ import cats.effect.IO
 
 // This project
 import resolver.registries.Registry
+import resolver.BlockerF
 
 object SpecHelpers {
 
@@ -60,6 +61,6 @@ object SpecHelpers {
       IO.delay(unit.convert(System.nanoTime(), TimeUnit.NANOSECONDS))
   }
 
-  val TestResolver = Resolver.init[IO](10, None, EmbeddedTest)
+  val TestResolver = Resolver.init[IO](10, None, BlockerF.noop[IO], EmbeddedTest)
   val TestClient   = for { resolver <- TestResolver } yield Client(resolver, CirceValidator)
 }

--- a/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
@@ -76,7 +76,14 @@ class ResolverSpec extends Specification with DataTables with ValidatedMatchers 
 
   def e1 = {
     val resolver =
-      Resolver.init[IO](10, None, SpecHelpers.IgluCentral, Repos.one, Repos.two, Repos.three)
+      Resolver.init[IO](
+        10,
+        None,
+        BlockerF.noop,
+        SpecHelpers.IgluCentral,
+        Repos.one,
+        Repos.two,
+        Repos.three)
     val schemaKey =
       SchemaKey("de.acompany.snowplow", "mobile_context", "jsonschema", SchemaVer.Full(1, 0, 0))
     val expected: List[Registry] =
@@ -210,7 +217,7 @@ class ResolverSpec extends Specification with DataTables with ValidatedMatchers 
     implicit val registryLookup = ResolverSpecHelpers.getLookup(responses, Nil)
 
     val result = for {
-      resolver  <- Resolver.init[StaticLookup](10, None, httpRep)
+      resolver  <- Resolver.init[StaticLookup](10, None, BlockerF.noop, httpRep)
       response1 <- resolver.lookupSchema(schemaKey)
       response2 <- resolver.lookupSchema(schemaKey)
       _         <- StaticLookup.addTime(600)
@@ -262,7 +269,7 @@ class ResolverSpec extends Specification with DataTables with ValidatedMatchers 
 
     val result = for {
       resolver <- Resolver
-        .init[StaticLookup](10, Some(1000), httpRep) // FIXME: its confusing to mix millis and sec
+        .init[StaticLookup](10, Some(1000), BlockerF.noop, httpRep) // FIXME: its confusing to mix millis and sec
       _      <- resolver.lookupSchema(schemaKey)
       _      <- StaticLookup.addTime(2000)
       _      <- resolver.lookupSchema(schemaKey)
@@ -324,7 +331,7 @@ class ResolverSpec extends Specification with DataTables with ValidatedMatchers 
       ))
 
     val result = for {
-      resolver <- Resolver.init[StaticLookup](10, Some(100), httpRep1, httpRep2)
+      resolver <- Resolver.init[StaticLookup](10, Some(100), BlockerF.noop, httpRep1, httpRep2)
       _        <- resolver.lookupSchema(schemaKey)
       _        <- StaticLookup.addTime(2000)
       result   <- resolver.lookupSchema(schemaKey)
@@ -384,7 +391,7 @@ class ResolverSpec extends Specification with DataTables with ValidatedMatchers 
         .HttpConnection(URI.create("https://com-iglucentral-eu1-prod.iglu.snplow.net/api"), None)
     )
 
-    val resolver = Resolver.init[Id](10, None, IgluCentralServer)
+    val resolver = Resolver.init[Id](10, None, BlockerF.noop, IgluCentralServer)
 
     val resultOne = resolver.listSchemas("com.sendgrid", "bounce", 2)
     val resultTwo = resolver.listSchemas("com.sendgrid", "bounce", 1)

--- a/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpecHelpers.scala
+++ b/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpecHelpers.scala
@@ -115,7 +115,8 @@ object ResolverSpecHelpers {
     new RegistryLookup[StaticLookup] {
       def lookup(
         repositoryRef: Registry,
-        schemaKey: SchemaKey): StaticLookup[Either[RegistryError, Json]] =
+        schemaKey: SchemaKey,
+        blocker: BlockerF[StaticLookup]): StaticLookup[Either[RegistryError, Json]] =
         State { x =>
           repositoryRef match {
             case Registry.Embedded(_, _) => (x.tick, RegistryError.NotFound.asLeft)
@@ -131,7 +132,8 @@ object ResolverSpecHelpers {
         registry: Registry,
         vendor: String,
         name: String,
-        model: Int): StaticLookup[Either[RegistryError, SchemaList]] =
+        model: Int,
+        blocker: BlockerF[StaticLookup]): StaticLookup[Either[RegistryError, SchemaList]] =
         State { x =>
           l.filter(key => key.vendor == vendor && key.name == name && model == key.version.model) match {
             case Nil  => (x, Left(RegistryError.NotFound))
@@ -145,7 +147,8 @@ object ResolverSpecHelpers {
     new RegistryLookup[StaticLookup] {
       def lookup(
         repositoryRef: Registry,
-        key: SchemaKey): StaticLookup[Either[RegistryError, Json]] =
+        key: SchemaKey,
+        blocker: BlockerF[StaticLookup]): StaticLookup[Either[RegistryError, Json]] =
         State { state =>
           val name = repositoryRef.config.name
           requestsMap.get(name) match {
@@ -160,7 +163,8 @@ object ResolverSpecHelpers {
         registry: Registry,
         vendor: String,
         name: String,
-        model: Int): StaticLookup[Either[RegistryError, SchemaList]] =
+        model: Int,
+        blocker: BlockerF[StaticLookup]): StaticLookup[Either[RegistryError, SchemaList]] =
         State { x =>
           l.filter(key => key.vendor == vendor && key.name == name && model == key.version.model) match {
             case Nil  => (x, Left(RegistryError.NotFound))


### PR DESCRIPTION
This PR is offered as a proof of concept, for discussion and to demo what the client will look like if we continue on this root.  I do not suggest we merge it yet.

This follows [the discussion in Enrich](https://github.com/snowplow/enrich/pull/433) about the need to run blocking operations on a dedicated thread pool, especially for apps with a small primary thread pool, e.g. cats-effect IO apps.  This PR solves the problem by passing around a _wrapper_ around a `cats.effect.Blocker`.  It needs to be wrapped, because `Id` apps do not have a `ContextShift` so they cannot directly call `Blocker.blockOn`.

We have discussed breaking out the `BlockerF` into its own micro-library.  Here I include it as part of of the iglu client library for convenience.