### PR TITLE
Schema override (1.x)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 1.4.0 (2023-05-03)
+--------------------------
+Take superseding schema into account during validation (#231)
+
 Version 1.3.1 (2023-04-26)
 --------------------------
 Ignore `$ref` keyword referencing HTTP resources (#238)

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Iglu Scala Client is used extensively in **[Snowplow][snowplow-repo]** to valida
 
 ## Installation
 
-The latest version of Iglu Scala Client is 1.3.1, which currently works with Scala 2.12 and 2.13.
+The latest version of Iglu Scala Client is 1.4.0, which currently works with Scala 2.12 and 2.13.
 
 If you're using SBT, add the following lines to your build file:
 
 ```scala
-val igluClient = "com.snowplowanalytics" %% "iglu-scala-client" % "1.3.1"
+val igluClient = "com.snowplowanalytics" %% "iglu-scala-client" % "1.4.0"
 ```
 
 ## API

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/Client.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/Client.scala
@@ -42,9 +42,9 @@ final case class Client[F[_], A](resolver: Resolver[F], validator: Validator[A])
     for {
       schema <- EitherT(resolver.lookupSchema(instance.schema))
       schemaValidation = validator.validateSchema(schema)
-      _ <- EitherT.fromEither[F](schemaValidation).leftMap(_.toClientError)
+      _ <- EitherT.fromEither[F](schemaValidation).leftMap(_.toClientError(None))
       validation = validator.validate(instance.data, schema)
-      _ <- EitherT.fromEither[F](validation).leftMap(_.toClientError)
+      _ <- EitherT.fromEither[F](validation).leftMap(_.toClientError(None))
     } yield ()
 }
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/IgluCirceClient.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/IgluCirceClient.scala
@@ -18,6 +18,7 @@ import cats.effect.Clock
 import cats.implicits._
 import com.snowplowanalytics.iglu.client.resolver.registries.RegistryLookup
 import com.snowplowanalytics.iglu.client.resolver.{InitListCache, InitSchemaCache}
+import com.snowplowanalytics.iglu.client.resolver.Resolver.SupersededBy
 import com.snowplowanalytics.iglu.client.validator.CirceValidator.WithCaching.{
   InitValidatorCache,
   SchemaEvaluationCache,
@@ -43,13 +44,19 @@ final class IgluCirceClient[F[_]] private (
     M: Monad[F],
     L: RegistryLookup[F],
     C: Clock[F]
-  ): EitherT[F, ClientError, Unit] =
+  ): EitherT[F, ClientError, SupersededBy] =
     for {
-      resolverResult <- EitherT(resolver.lookupSchemaResult(instance.schema))
+      resolverResult <- EitherT(
+        resolver.lookupSchemaResult(instance.schema, resolveSupersedingSchema = true)
+      )
       validation =
         CirceValidator.WithCaching.validate(schemaEvaluationCache)(instance.data, resolverResult)
-      _ <- EitherT(validation).leftMap(_.toClientError)
-    } yield ()
+      _ <- EitherT(validation).leftMap(e =>
+        e.toClientError(resolverResult.value.supersededBy.map(_.asString))
+      )
+      // Returning superseding schema info as well since we want to inform caller that sdj is validated
+      // against superseding schema if it is superseded by another schema.
+    } yield resolverResult.value.supersededBy
 }
 
 object IgluCirceClient {

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/ResolverCache.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/ResolverCache.scala
@@ -19,14 +19,13 @@ import cats.effect.Clock
 import cats.implicits._
 import com.snowplowanalytics.iglu.core.SchemaList
 
-// circe
-import io.circe.Json
-
 // LruMap
 import com.snowplowanalytics.lrumap.{CreateLruMap, LruMap}
 
 // Iglu core
 import com.snowplowanalytics.iglu.core.SchemaKey
+
+import Resolver.SchemaItem
 
 /**
  * Resolver cache and associated logic to (in)validate entities,
@@ -93,7 +92,7 @@ class ResolverCache[F[_]] private (
   )(implicit
     F: Monad[F],
     C: Clock[F]
-  ): F[Either[LookupFailureMap, TimestampedItem[Json]]] =
+  ): F[Either[LookupFailureMap, TimestampedItem[SchemaItem]]] =
     putItemResult(schemas, schemaKey, freshResult)
 
   /** Lookup a `SchemaList`, no TTL is available */

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/package.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/package.scala
@@ -12,9 +12,6 @@
  */
 package com.snowplowanalytics.iglu.client
 
-// circe
-import io.circe.Json
-
 // LRU
 import com.snowplowanalytics.lrumap.CreateLruMap
 
@@ -23,6 +20,7 @@ import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaList}
 
 // This project
 import resolver.registries.Registry
+import resolver.Resolver.SchemaItem
 
 package object resolver {
 
@@ -38,7 +36,7 @@ package object resolver {
    * Json in case of success or Map of all currently failed repositories
    * in case of failure
    */
-  type SchemaLookup = Either[LookupFailureMap, Json]
+  type SchemaLookup = Either[LookupFailureMap, SchemaItem]
 
   type ListLookup = Either[LookupFailureMap, SchemaList]
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/validator/CirceValidator.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/validator/CirceValidator.scala
@@ -42,7 +42,7 @@ import io.circe.jackson.snowplow.circeToJackson
 import com.snowplowanalytics.lrumap.{CreateLruMap, LruMap}
 
 import com.snowplowanalytics.iglu.core.SchemaKey
-import com.snowplowanalytics.iglu.client.resolver.Resolver.ResolverResult
+import com.snowplowanalytics.iglu.client.resolver.Resolver.{ResolverResult, SchemaItem}
 
 object CirceValidator extends Validator[Json] {
 
@@ -311,7 +311,7 @@ object CirceValidator extends Validator[Json] {
       evaluationCache: SchemaEvaluationCache[F]
     )(result: SchemaLookupResult): F[Either[ValidatorError.InvalidSchema, JsonSchema]] = {
       result match {
-        case ResolverResult.Cached(key, schema, timestamp) =>
+        case ResolverResult.Cached(key, SchemaItem(schema, _), timestamp) =>
           evaluationCache.get((key, timestamp)).flatMap {
             case Some(alreadyEvaluatedSchema) =>
               alreadyEvaluatedSchema.pure[F]
@@ -320,7 +320,7 @@ object CirceValidator extends Validator[Json] {
                 .pure[F]
                 .flatTap(result => evaluationCache.put((key, timestamp), result))
           }
-        case ResolverResult.NotCached(schema) =>
+        case ResolverResult.NotCached(SchemaItem(schema, _)) =>
           provideNewJsonSchema(schema).pure[F]
       }
     }

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/validator/ValidatorError.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/validator/ValidatorError.scala
@@ -20,7 +20,8 @@ import cats.data.NonEmptyList
 
 /** ADT describing issues that can be discovered by Validator */
 sealed trait ValidatorError extends Product with Serializable {
-  def toClientError: ClientError = ClientError.ValidationError(this)
+  def toClientError(supersededBy: Option[String]): ClientError =
+    ClientError.ValidationError(this, supersededBy)
 }
 
 object ValidatorError {

--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/invalid-superseded-schema/jsonschema/1-0-0
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/invalid-superseded-schema/jsonschema/1-0-0
@@ -1,0 +1,21 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Test schema",
+    "$supersededBy": "1-0",
+	"self": {
+		"vendor": "com.snowplowanalytics.iglu-test",
+		"name": "invalid-superseded-schema",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		}
+	},
+
+	"required": ["id"],
+	"additionalProperties": false
+}

--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/invalid-superseded-schema/jsonschema/1-0-1
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/invalid-superseded-schema/jsonschema/1-0-1
@@ -1,0 +1,24 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Test schema",
+	"$supersededBy": "1-0-3",
+	"self": {
+		"vendor": "com.snowplowanalytics.iglu-test",
+		"name": "invalid-superseded-schema",
+		"format": "jsonschema",
+		"version": "1-0-1"
+	},
+
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+
+	"required": ["id"],
+	"additionalProperties": false
+}

--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/invalid-superseded-schema/jsonschema/1-0-2
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/invalid-superseded-schema/jsonschema/1-0-2
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Test schema",
+    "$supersededBy": "1-0-1",
+	"self": {
+		"vendor": "com.snowplowanalytics.iglu-test",
+		"name": "invalid-superseded-schema",
+		"format": "jsonschema",
+		"version": "1-0-2"
+	},
+
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"price": {
+			"type": "number"
+		}
+	},
+
+	"required": ["id"],
+	"additionalProperties": false
+}

--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-0
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-0
@@ -1,0 +1,21 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Test schema",
+    "$supersededBy": "1-0-2",
+	"self": {
+		"vendor": "com.snowplowanalytics.iglu-test",
+		"name": "superseded-schema",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		}
+	},
+
+	"required": ["id"],
+	"additionalProperties": false
+}

--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-1
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-1
@@ -1,0 +1,23 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Test schema",
+	"self": {
+		"vendor": "com.snowplowanalytics.iglu-test",
+		"name": "superseded-schema",
+		"format": "jsonschema",
+		"version": "1-0-1"
+	},
+
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		}
+	},
+
+	"required": ["id"],
+	"additionalProperties": false
+}

--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-2
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-2
@@ -1,0 +1,26 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Test schema",
+	"self": {
+		"vendor": "com.snowplowanalytics.iglu-test",
+		"name": "superseded-schema",
+		"format": "jsonschema",
+		"version": "1-0-2"
+	},
+
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},
+		"price": {
+			"type": "number"
+		}
+	},
+
+	"required": ["id"],
+	"additionalProperties": false
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/CachingClientSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/CachingClientSpec.scala
@@ -29,6 +29,9 @@ class CachingClientSpec extends Specification {
   validating a correct self-desc JSON should return the JSON in a Success $e1
   validating a correct self-desc JSON with JSON Schema with incorrect $$schema property should return Failure $e2
   validating an incorrect self-desc JSON should return the validation errors in a Failure  $e3
+  validating a correct self-desc JSON with superseded schema should return the JSON in a Success $e4
+  validating an incorrect self-desc JSON with superseded schema should return validation errors in a Failure  $e5
+  validating self-desc JSONs with invalid superseded schemas should return resolution errors $e6
 
   """
 
@@ -65,6 +68,72 @@ class CachingClientSpec extends Specification {
       json"""{"schema": "iglu://jsonschema/1-0-0", "data": { "id": 0 } }"""
     )
 
+  val validJsonWithSupersededSchema1 =
+    SelfDescribingData(
+      SchemaKey(
+        "com.snowplowanalytics.iglu-test",
+        "superseded-schema",
+        "jsonschema",
+        SchemaVer.Full(1, 0, 0)
+      ),
+      json"""{ "id": "test-id" }"""
+    )
+
+  val validJsonWithSupersededSchema2 =
+    SelfDescribingData(
+      SchemaKey(
+        "com.snowplowanalytics.iglu-test",
+        "superseded-schema",
+        "jsonschema",
+        SchemaVer.Full(1, 0, 0)
+      ),
+      json"""{ "id": "test-id", "name": "test-name" }"""
+    )
+
+  val invalidJsonWithSupersededSchema =
+    SelfDescribingData(
+      SchemaKey(
+        "com.snowplowanalytics.iglu-test",
+        "superseded-schema",
+        "jsonschema",
+        SchemaVer.Full(1, 0, 0)
+      ),
+      json"""{ "id": "test-id", "name": "test-name", "field_a": "value_a" }"""
+    )
+
+  val jsonWithInvalidSupersededSchema100 =
+    SelfDescribingData(
+      SchemaKey(
+        "com.snowplowanalytics.iglu-test",
+        "invalid-superseded-schema",
+        "jsonschema",
+        SchemaVer.Full(1, 0, 0)
+      ),
+      json"""{ "id": "test-id" }"""
+    )
+
+  val jsonWithInvalidSupersededSchema101 =
+    SelfDescribingData(
+      SchemaKey(
+        "com.snowplowanalytics.iglu-test",
+        "invalid-superseded-schema",
+        "jsonschema",
+        SchemaVer.Full(1, 0, 1)
+      ),
+      json"""{ "id": "test-id" }"""
+    )
+
+  val jsonWithInvalidSupersededSchema102 =
+    SelfDescribingData(
+      SchemaKey(
+        "com.snowplowanalytics.iglu-test",
+        "invalid-superseded-schema",
+        "jsonschema",
+        SchemaVer.Full(1, 0, 2)
+      ),
+      json"""{ "id": "test-id" }"""
+    )
+
   def e1 = {
     val action = for {
       client <- SpecHelpers.CachingTestClient
@@ -90,6 +159,72 @@ class CachingClientSpec extends Specification {
     } yield result must beLeft
 
     action.unsafeRunSync()
+  }
+
+  def e4 = {
+    val supersedingSchema = SchemaVer.Full(1, 0, 2)
+
+    val res1 = (
+      for {
+        client <- SpecHelpers.CachingTestClient
+        result <- client.check(validJsonWithSupersededSchema1).value
+      } yield result
+    ).unsafeRunSync()
+
+    val res2 = (
+      for {
+        client <- SpecHelpers.CachingTestClient
+        result <- client.check(validJsonWithSupersededSchema2).value
+      } yield result
+    ).unsafeRunSync()
+
+    (res1 must beRight(Some(supersedingSchema))) and
+      (res2 must beRight(Some(supersedingSchema)))
+  }
+
+  def e5 = {
+    val res = (
+      for {
+        client <- SpecHelpers.CachingTestClient
+        result <- client.check(invalidJsonWithSupersededSchema).value
+      } yield result
+    ).unsafeRunSync()
+
+    res must beLeft.like {
+      case ClientError.ValidationError(_, Some(supersededBy)) if supersededBy == "1-0-2" => ok
+      case _                                                                             => ko
+    }
+  }
+
+  def e6 = {
+    val res1 = (
+      for {
+        client <- SpecHelpers.CachingTestClient
+        result <- client.check(jsonWithInvalidSupersededSchema100).value
+      } yield result
+    ).unsafeRunSync()
+
+    val res2 = (
+      for {
+        client <- SpecHelpers.CachingTestClient
+        result <- client.check(jsonWithInvalidSupersededSchema101).value
+      } yield result
+    ).unsafeRunSync()
+
+    val res3 = (
+      for {
+        client <- SpecHelpers.CachingTestClient
+        result <- client.check(jsonWithInvalidSupersededSchema102).value
+      } yield result
+    ).unsafeRunSync()
+
+    val match1 = res1.toString must contain("Invalid schema version: 1-0")
+    val match2 = res2.toString must contain("Iglu Test Embedded -> LookupHistory(Set(NotFound)")
+    val match3 = res3.toString must contain(
+      "ClientFailure(Superseding version 1-0-1 isn't greater than the version of schema com.snowplowanalytics.iglu-test/invalid-superseded-schema/jsonschema/1-0-2)"
+    )
+
+    match1.and(match2).and(match3)
   }
 
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/ClientErrorSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/ClientErrorSpec.scala
@@ -91,12 +91,14 @@ class ClientErrorSpec extends Specification {
           ValidatorReport("Something went wrong again", None, Nil, None),
           ValidatorReport("Something went wrong with targets", None, List("type", "property"), None)
         )
-      )
+      ),
+      Some("1-0-0")
     )
 
     val json =
       json"""{
         "error" : "ValidationError",
+        "supersededBy": "1-0-0",
         "dataReports" : [
           {
             "message" : "Something went wrong",

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverResultSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverResultSpec.scala
@@ -42,6 +42,7 @@ import com.snowplowanalytics.iglu.client.resolver.registries.{Registry, Registry
 import com.snowplowanalytics.iglu.client.SpecHelpers._
 import org.specs2.Specification
 import org.specs2.matcher.{DataTables, ValidatedMatchers}
+import Resolver.SchemaItem
 
 /** Like 'ResolverSpec' but using lookup methods returning 'ResolverResult' */
 class ResolverResultSpec extends Specification with DataTables with ValidatedMatchers {
@@ -62,6 +63,8 @@ class ResolverResultSpec extends Specification with DataTables with ValidatedMat
   a Resolver should not cache schema if cache is disabled $e12
   a Resolver should return cached schema when ttl not exceeded $e13
   a Resolver should return cached schema when ttl exceeded $e14
+  a Resolver should return superseding schema if resolveSupersedingSchema is true $e15
+  a Resolver shouldn't return superseding schema if resolveSupersedingSchema is false $e16
   """
 
   import ResolverSpec._
@@ -231,7 +234,7 @@ class ResolverResultSpec extends Specification with DataTables with ValidatedMat
     }
 
     val thirdSucceeded = response3 must beRight[SchemaLookupResult].like {
-      case ResolverResult.Cached(key, value, _) =>
+      case ResolverResult.Cached(key, SchemaItem(value, _), _) =>
         key must beEqualTo(schemaKey) and (value must beEqualTo(Json.Null))
     }
     val requestsNumber = state.req must beEqualTo(2)
@@ -280,7 +283,7 @@ class ResolverResultSpec extends Specification with DataTables with ValidatedMat
 
     // Final response must not overwrite a successful one
     val finalResult = response must beRight[SchemaLookupResult].like {
-      case ResolverResult.Cached(key, value, _) =>
+      case ResolverResult.Cached(key, SchemaItem(value, _), _) =>
         key must beEqualTo(schemaKey) and (value must beEqualTo(Json.Null))
     }
 
@@ -433,7 +436,7 @@ class ResolverResultSpec extends Specification with DataTables with ValidatedMat
       .flatMap(resolver => resolver.lookupSchemaResult(schemaKey))
       .unsafeRunSync()
 
-    result must beRight(ResolverResult.NotCached(expectedSchema))
+    result must beRight(ResolverResult.NotCached(SchemaItem(expectedSchema, None)))
   }
 
   def e13 = {
@@ -514,5 +517,67 @@ class ResolverResultSpec extends Specification with DataTables with ValidatedMat
             ) and (timestamp1 mustNotEqual timestamp2) // same value but different timestamps because original item expired
         }
     }
+  }
+
+  def e15 = {
+
+    val expectedSchema: Json =
+      parse(
+        scala.io.Source
+          .fromInputStream(
+            getClass.getResourceAsStream(
+              "/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-2"
+            )
+          )
+          .mkString
+      )
+        .fold(e => throw new RuntimeException(s"Cannot parse superseded schema, $e"), identity)
+
+    val schemaKey = SchemaKey(
+      "com.snowplowanalytics.iglu-test",
+      "superseded-schema",
+      "jsonschema",
+      SchemaVer.Full(1, 0, 0)
+    )
+
+    val result = Resolver
+      .init[IO](cacheSize = 0, cacheTtl = None, refs = EmbeddedTest)
+      .flatMap(resolver => resolver.lookupSchemaResult(schemaKey, resolveSupersedingSchema = true))
+      .unsafeRunSync()
+
+    result must beRight(
+      ResolverResult.NotCached(SchemaItem(expectedSchema, Some(SchemaVer.Full(1, 0, 2))))
+    )
+  }
+
+  def e16 = {
+
+    val expectedSchema: Json =
+      parse(
+        scala.io.Source
+          .fromInputStream(
+            getClass.getResourceAsStream(
+              "/iglu-test-embedded/schemas/com.snowplowanalytics.iglu-test/superseded-schema/jsonschema/1-0-0"
+            )
+          )
+          .mkString
+      )
+        .fold(e => throw new RuntimeException(s"Cannot parse superseded schema, $e"), identity)
+
+    val schemaKey = SchemaKey(
+      "com.snowplowanalytics.iglu-test",
+      "superseded-schema",
+      "jsonschema",
+      SchemaVer.Full(1, 0, 0)
+    )
+
+    val result = Resolver
+      .init[IO](cacheSize = 0, cacheTtl = None, refs = EmbeddedTest)
+      .flatMap(resolver => resolver.lookupSchemaResult(schemaKey))
+      .unsafeRunSync()
+
+    result must beRight(
+      ResolverResult.NotCached(SchemaItem(expectedSchema, None))
+    )
   }
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/validator/CachingValidationSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/validator/CachingValidationSpec.scala
@@ -33,6 +33,8 @@ import io.circe.parser.parse
 import org.specs2.Specification
 import org.specs2.matcher.DataTables
 
+import com.snowplowanalytics.iglu.client.resolver.Resolver.SchemaItem
+
 class CachingValidationSpec extends Specification with DataTables {
   def is = s2"""
 
@@ -84,7 +86,10 @@ class CachingValidationSpec extends Specification with DataTables {
     ) { json =>
       val result =
         CirceValidator.WithCaching
-          .validate(createCache())(json, ResolverResult.NotCached(simpleSchemaResult))
+          .validate(createCache())(
+            json,
+            ResolverResult.NotCached(SchemaItem(simpleSchemaResult, None))
+          )
 
       result must beRight
     }
@@ -146,7 +151,7 @@ class CachingValidationSpec extends Specification with DataTables {
       CirceValidator.WithCaching
         .validate(createCache())(
           nonStringInput,
-          ResolverResult.NotCached(simpleSchemaResult)
+          ResolverResult.NotCached(SchemaItem(simpleSchemaResult, None))
         ) must beLeft(
         nonStringExpected
       )
@@ -154,7 +159,7 @@ class CachingValidationSpec extends Specification with DataTables {
       CirceValidator.WithCaching
         .validate(createCache())(
           missingKeyInput,
-          ResolverResult.NotCached(simpleSchemaResult)
+          ResolverResult.NotCached(SchemaItem(simpleSchemaResult, None))
         ) must beLeft(
         missingKeyExpected
       )
@@ -162,7 +167,7 @@ class CachingValidationSpec extends Specification with DataTables {
       CirceValidator.WithCaching
         .validate(createCache())(
           heterogeneusArrayInput,
-          ResolverResult.NotCached(simpleSchemaResult)
+          ResolverResult.NotCached(SchemaItem(simpleSchemaResult, None))
         ) must beLeft(
         heterogeneusArrayExpected
       )
@@ -170,7 +175,7 @@ class CachingValidationSpec extends Specification with DataTables {
       CirceValidator.WithCaching
         .validate(createCache())(
           doubleErrorInput,
-          ResolverResult.NotCached(simpleSchemaResult)
+          ResolverResult.NotCached(SchemaItem(simpleSchemaResult, None))
         ) must beLeft(
         doubleErrorExpected
       )
@@ -199,7 +204,10 @@ class CachingValidationSpec extends Specification with DataTables {
     )
 
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beLeft(
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beLeft(
       expected
     )
   }
@@ -215,7 +223,10 @@ class CachingValidationSpec extends Specification with DataTables {
     val input  = json"""{"shortKey": 5 }"""
 
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beRight
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beRight
   }
 
   def e5 = {
@@ -245,7 +256,10 @@ class CachingValidationSpec extends Specification with DataTables {
     )
 
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beLeft(
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beLeft(
       expected
     )
   }
@@ -274,7 +288,10 @@ class CachingValidationSpec extends Specification with DataTables {
     )
 
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beLeft(
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beLeft(
       expected
     )
   }
@@ -283,28 +300,40 @@ class CachingValidationSpec extends Specification with DataTables {
     val schema = json"""{ "type": "integer" }"""
     val input  = json"""9223372036854775809"""
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beRight
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beRight
   }
 
   def e8 = {
     val schema = json"""{ "type": ["array", "null"], "items": {"type": "object"} }"""
     val input  = json"""null"""
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beRight
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beRight
   }
 
   def e9 = {
     val schema = json"""{ "type": "integer" }"""
     val input  = json""""5""""
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beLeft
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beLeft
   }
 
   def e10 = {
     val schema = json"""{ "type": "number" }"""
     val input  = json"""5"""
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beRight
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beRight
 
   }
 
@@ -322,7 +351,10 @@ class CachingValidationSpec extends Specification with DataTables {
     )
 
     CirceValidator.WithCaching
-      .validate(createCache())(input, ResolverResult.NotCached(schema)) must beLeft(
+      .validate(createCache())(
+        input,
+        ResolverResult.NotCached(SchemaItem(schema, None))
+      ) must beLeft(
       expected
     )
 
@@ -336,7 +368,10 @@ class CachingValidationSpec extends Specification with DataTables {
     val input  = json"""5"""
     val result =
       CirceValidator.WithCaching
-        .validate(cache)(input, ResolverResult.Cached(schemaKey, schema, timestamp = 1))
+        .validate(cache)(
+          input,
+          ResolverResult.Cached(schemaKey, SchemaItem(schema, None), timestamp = 1)
+        )
 
     result must beRight(()) and
       (cache.get((schemaKey, 1)) must beSome)
@@ -348,7 +383,9 @@ class CachingValidationSpec extends Specification with DataTables {
 
     val schema = json"""{ "type": "number" }"""
     val input  = json"""5"""
-    val result = CirceValidator.WithCaching.validate(cache)(input, ResolverResult.NotCached(schema))
+    val result =
+      CirceValidator.WithCaching
+        .validate(cache)(input, ResolverResult.NotCached(SchemaItem(schema, None)))
 
     result must beRight(()) and
       (cache.get((schemaKey, 1)) must beNone)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -21,6 +21,7 @@ import sbtdynver.DynVerPlugin.autoImport._
 // Mima plugin
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
+import com.typesafe.tools.mima.core.{ProblemFilters, MissingTypesProblem}
 
 // Scoverage plugin
 import scoverage.ScoverageKeys._
@@ -69,7 +70,7 @@ object BuildSettings {
   // clear-out mimaBinaryIssueFilters and mimaPreviousVersions.
   // Otherwise, add previous version to set without
   // removing other versions.
-  val mimaPreviousVersionsCore = Set("1.1.1")
+  val mimaPreviousVersionsCore = Set()
   val mimaPreviousVersionsHttp4s = Set()
 
   lazy val mimaSettings = Seq(
@@ -78,7 +79,8 @@ object BuildSettings {
       mimaPreviousVersions.map { organization.value %% name.value % _ },
     },
     ThisBuild / mimaFailOnNoPrevious := false,
-    mimaBinaryIssueFilters ++= Seq(),
+    mimaBinaryIssueFilters ++= Seq(
+    ),
     Test / test := {
       mimaReportBinaryIssues.value
       (Test / test).value


### PR DESCRIPTION
Iglu Scala Client is updated such that it will take supersededBy into account while validating the self-describing JSONs. It should check the content of the schema first. If it contains supersededBy field, it should retrieve superseding schema.

The next change is caching. At the moment, schemas are cached in the Iglu Scala Client. With the introduction of supersededBy feature, superseding schema key should also be cached because this schema key needs to be returned to caller after validation because superseded schema key needs to be replaced with superseding schema key. Previously, cached item type was this: `Either[LookupFailureMap, Json]`. It become like this after the change: `Either[LookupFailureMap, (Json, Option[SchemaVer.Full])]`. Schema version that is stored beside schema JSON will be the version of the superseding schema.

The next change is return value of `check` function. At the moment, its return type is `Either[ClientError, Unit]`. Effectively, it returns Unit when validation is successful. However, with supersededBy feature, we want it to return superseding schema version. Then, this value will be used on the caller side.