### PR TITLE
Json validator hardening

### DIFF
--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/validator/SchemaValidationSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/validator/SchemaValidationSpec.scala
@@ -64,7 +64,7 @@ class SchemaValidationSpec extends Specification with CatsEffect {
         "jsonschema",
         SchemaVer.Full(1, 0, 0)
       ),
-      json"""{"schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#", "data": { "id": 0 } }"""
+      json"""{"schema": "iglu:com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0", "data": { "id": 0 } }"""
     )
 
   val testResolver = SpecHelpers.TestResolver


### PR DESCRIPTION
If the json validator encounters a schema which exists, but has the wrong meta-schema, the current implementation will crash hard.

This pull request fixes that issue by wrapping all calls to the underlying library in Either.catchNonFatal