### PR TITLE
Fix listSchemasLike when multiple Iglu repositories host the schemas

### DIFF
--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-0
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-0
@@ -1,0 +1,38 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a client-generated user session",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "client_session",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"userId": {
+			"type": "string",
+			"pattern": "^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$|^[0-9a-f]{16}$"
+		},
+		"sessionId": {
+			"type": "string",
+			"format": "uuid"
+		},
+		"sessionIndex": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 2147483647
+		},
+		"previousSessionId": {
+			"type": [
+				"null",
+				"string"
+			],
+			"format": "uuid"
+		},
+		"storageMechanism": {
+			"enum": [ "SQLITE", "COOKIE_1", "COOKIE_3", "LOCAL_STORAGE", "FLASH_LSO" ]
+		}
+	},
+	"required": [ "userId", "sessionId", "sessionIndex", "previousSessionId", "storageMechanism" ],
+	"additionalProperties": false
+}

--- a/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1
+++ b/modules/core/src/test/resources/iglu-test-embedded/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1
@@ -1,0 +1,53 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a client-generated user session",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "client_session",
+		"format": "jsonschema",
+		"version": "1-0-1"
+	},
+	"type": "object",
+	"properties": {
+		"userId": {
+			"type": "string",
+			"pattern": "^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$|^[0-9a-f]{16}$",
+			"maxLength": 36,
+			"description": "An identifier for the user of the session"
+		},
+		"sessionId": {
+			"type": "string",
+			"format": "uuid",
+			"description": "An identifier for the session"
+		},
+		"sessionIndex": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 2147483647,
+			"description": "The index of the current session for this user"
+		},
+		"previousSessionId": {
+			"type": [
+				"null",
+				"string"
+			],
+			"format": "uuid",
+			"description": "The previous session identifier for this user"
+		},
+		"storageMechanism": {
+			"type": "string",
+			"enum": [ "SQLITE", "COOKIE_1", "COOKIE_3", "LOCAL_STORAGE", "FLASH_LSO" ],
+			"description": "The mechanism that the session information has been stored on the device"
+		},
+		"firstEventId": {
+			"type": [
+				"null",
+				"string"
+			],
+			"format": "uuid",
+			"description": "The optional identifier of the first event id for this session"
+		}
+	},
+	"required": [ "userId", "sessionId", "sessionIndex", "previousSessionId", "storageMechanism" ],
+	"additionalProperties": false
+}


### PR DESCRIPTION
Jira ref: PDP-1226

We had a problem with listSchemasLike when using the mustIncludeKey option, which was introduced in #215

For a particular schema...

- Iglu Server 1 hosted versions `1-0-0` and `1-0-1`
- Iglu Server 2 hosted versions `1-0-0`, `1-0-1`, `1-0-2` and `1-0-3`

and `mustIncludeKey` was set to `1-0-3`. But `listSchemasLike` returned only `1-0-0` and `1-0-1` because Iglu Server 1 had higher priority.

After this change, `listSchemasLike` will return the list from Iglu Server 2 under these circumstances. Even though it has lower priority, it is the server that contains the `mustIncludeKey`.