### PR TITLE
Add caching to lookupSchemasUntil function

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/CreateResolverCache.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/CreateResolverCache.scala
@@ -25,6 +25,8 @@ trait CreateResolverCache[F[_]] {
 
   def createSchemaListCache(size: Int): F[LruMap[F, ListCacheKey, ListCacheEntry]]
 
+  def createSchemaContentListCache(size: Int): F[LruMap[F, SchemaKey, SchemaContentListCacheEntry]]
+
   def createMutex[K]: F[ResolverMutex[F, K]]
 
 }
@@ -43,6 +45,10 @@ object CreateResolverCache {
     override def createSchemaListCache(size: Int): F[LruMap[F, ListCacheKey, ListCacheEntry]] =
       createLruMap(size)
 
+    override def createSchemaContentListCache(
+      size: Int
+    ): F[LruMap[F, SchemaKey, SchemaContentListCacheEntry]] =
+      createLruMap(size)
   }
 
   implicit def idCreateResolverCache: CreateResolverCache[Id] =

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/package.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/package.scala
@@ -14,8 +14,12 @@ package com.snowplowanalytics.iglu.client
 
 import scala.concurrent.duration.FiniteDuration
 
+import cats.data.NonEmptyList
+
+import io.circe.Json
+
 // Iglu Core
-import com.snowplowanalytics.iglu.core.SchemaList
+import com.snowplowanalytics.iglu.core.{SchemaList, SelfDescribingSchema}
 
 // This project
 import resolver.registries.Registry
@@ -31,6 +35,8 @@ package object resolver {
 
   /** Schema's model */
   type Model = Int
+
+  type SchemaContentList = NonEmptyList[SelfDescribingSchema[Json]]
 
   /**
    * Map of all repositories to its aggregated state of failure
@@ -52,6 +58,13 @@ package object resolver {
    * in case of failure
    */
   type ListLookup = Either[LookupFailureMap, SchemaList]
+
+  /**
+   * Validated schema content list lookup result containing, cache result
+   * which is list of self describing schemas in case of success or
+   * Map of all currently failed repositories in case of failure
+   */
+  type SchemaContentListLookup = Either[LookupFailureMap, SchemaContentList]
 
   /** Time to live for cached items */
   type TTL = FiniteDuration
@@ -76,5 +89,8 @@ package object resolver {
 
   /** Cache entry for schema list lookup results */
   type ListCacheEntry = CacheEntry[ListLookup]
+
+  /** Cache entry for schema content list lookup results */
+  type SchemaContentListCacheEntry = CacheEntry[SchemaContentListLookup]
 
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverCacheSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverCacheSpec.scala
@@ -46,7 +46,8 @@ class ResolverCacheSpec extends Specification {
         4.millis,
         List((key, (2.millis, Right(SchemaItem(Json.Null, None))))),
         5,
-        List()
+        List(),
+        Map.empty
       )
 
     val test = for {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -68,7 +68,7 @@ object BuildSettings {
   // clear-out mimaBinaryIssueFilters and mimaPreviousVersions.
   // Otherwise, add previous version to set without
   // removing other versions.
-  val mimaPreviousVersions = Set("3.0.0")
+  val mimaPreviousVersions = Set()
 
   lazy val mimaSettings = Seq(
     mimaPreviousArtifacts := {


### PR DESCRIPTION
Jira ref: PDP-1479

This PR adds caching to `lookupSchemasUntil` function. Also, `lookupSchemasUntilResult` function is implemented as well. It is the variant of `lookupSchemasUntil` that returns `ResolverResult` which contains information about cahe item.