### PR TITLE
Remove entropy from client failures

### DIFF
--- a/modules/http4s/src/main/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookup.scala
+++ b/modules/http4s/src/main/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookup.scala
@@ -134,10 +134,8 @@ object Http4sRegistryLookup {
           RegistryError.RepoFailure(error).asLeft
         }
       case Status.ClientError(response) =>
-        response.bodyText.compile.string.map { body =>
-          val error = s"Unexpected server response: $body"
-          RegistryError.ClientFailure(error).asLeft
-        }
+        val error = s"Unexpected server response: ${response.status.code}"
+        (RegistryError.ClientFailure(error): RegistryError).asLeft[A].pure[F]
       case response =>
         response.bodyText.compile.string.map { body =>
           val error = s"Unexpected response: $body"

--- a/modules/http4s/src/main/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookup.scala
+++ b/modules/http4s/src/main/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookup.scala
@@ -134,7 +134,7 @@ object Http4sRegistryLookup {
           RegistryError.RepoFailure(error).asLeft
         }
       case Status.ClientError(response) =>
-        val error = s"Unexpected server response: ${response.status.code}"
+        val error = s"Unexpected response code: ${response.status.code}"
         (RegistryError.ClientFailure(error): RegistryError).asLeft[A].pure[F]
       case response =>
         response.bodyText.compile.string.map { body =>

--- a/modules/http4s/src/test/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookupSpec.scala
+++ b/modules/http4s/src/test/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookupSpec.scala
@@ -20,7 +20,6 @@ import io.circe.Json
 import org.http4s.client.{Client => HttpClient}
 import org.http4s.dsl.Http4sDsl
 import org.http4s.implicits._
-import org.http4s.Status._
 import org.specs2.mutable.Specification
 
 import java.net.URI
@@ -102,7 +101,7 @@ class Http4sRegistryLookupSpec extends Specification with CatsEffect {
       }
 
       Http4sRegistryLookup(client).lookup(repositoryRef, schemaKey).map { result =>
-        result should beLeft(ClientFailure(s"Unexpected response code: ${Forbidden.code}"))
+        result should beLeft(ClientFailure("Unexpected response code: 403"))
       }
     }
 
@@ -121,7 +120,7 @@ class Http4sRegistryLookupSpec extends Specification with CatsEffect {
       }
 
       Http4sRegistryLookup(client).lookup(repositoryRef, schemaKey).map { result =>
-        result should beLeft(ClientFailure(s"Unexpected response code: ${RequestTimeout.code}"))
+        result should beLeft(ClientFailure("Unexpected response code: 408"))
       }
     }
   }

--- a/modules/http4s/src/test/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookupSpec.scala
+++ b/modules/http4s/src/test/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookupSpec.scala
@@ -102,7 +102,7 @@ class Http4sRegistryLookupSpec extends Specification with CatsEffect {
       }
 
       Http4sRegistryLookup(client).lookup(repositoryRef, schemaKey).map { result =>
-        result should beLeft(ClientFailure(s"Unexpected server response: ${Forbidden.code}"))
+        result should beLeft(ClientFailure(s"Unexpected response code: ${Forbidden.code}"))
       }
     }
 
@@ -121,7 +121,7 @@ class Http4sRegistryLookupSpec extends Specification with CatsEffect {
       }
 
       Http4sRegistryLookup(client).lookup(repositoryRef, schemaKey).map { result =>
-        result should beLeft(ClientFailure(s"Unexpected server response: ${RequestTimeout.code}"))
+        result should beLeft(ClientFailure(s"Unexpected response code: ${RequestTimeout.code}"))
       }
     }
   }

--- a/modules/http4s/src/test/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookupSpec.scala
+++ b/modules/http4s/src/test/scala/com.snowplowanalytics.iglu/client/resolver/registries/Http4sRegistryLookupSpec.scala
@@ -14,11 +14,13 @@ package com.snowplowanalytics.iglu.client.resolver.registries
 
 import cats.effect.testing.specs2.CatsEffect
 import cats.effect.{IO, Resource}
+import com.snowplowanalytics.iglu.client.resolver.registries.RegistryError.ClientFailure
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaList, SchemaVer}
 import io.circe.Json
 import org.http4s.client.{Client => HttpClient}
 import org.http4s.dsl.Http4sDsl
 import org.http4s.implicits._
+import org.http4s.Status._
 import org.specs2.mutable.Specification
 
 import java.net.URI
@@ -82,6 +84,44 @@ class Http4sRegistryLookupSpec extends Specification with CatsEffect {
 
       Http4sRegistryLookup(client).lookup(repositoryRef, schemaKey).map { result =>
         result should beLeft
+      }
+    }
+
+    "return a registry error with status code only for a client failure - Forbidden" in {
+
+      val repositoryRef =
+        Registry.Http(
+          Registry.Config("name", 1, Nil),
+          Registry.HttpConnection(URI.create("http://custom-iglu.com"), None)
+        )
+      val schemaKey = SchemaKey("com.myvendor", "status", "jsonschema", SchemaVer.Full(42, 42, 42))
+
+      val client = HttpClient[IO] { _ =>
+        val dsl = new Http4sDsl[IO] {}; import dsl._
+        Resource.eval(Forbidden("forbidden"))
+      }
+
+      Http4sRegistryLookup(client).lookup(repositoryRef, schemaKey).map { result =>
+        result should beLeft(ClientFailure(s"Unexpected server response: ${Forbidden.code}"))
+      }
+    }
+
+    "return a registry error with status code only for a client failure - RequestTimeout" in {
+
+      val repositoryRef =
+        Registry.Http(
+          Registry.Config("name", 1, Nil),
+          Registry.HttpConnection(URI.create("http://custom-iglu.com"), None)
+        )
+      val schemaKey = SchemaKey("com.myvendor", "status", "jsonschema", SchemaVer.Full(42, 42, 42))
+
+      val client = HttpClient[IO] { _ =>
+        val dsl = new Http4sDsl[IO] {}; import dsl._
+        Resource.eval(RequestTimeout("timeout"))
+      }
+
+      Http4sRegistryLookup(client).lookup(repositoryRef, schemaKey).map { result =>
+        result should beLeft(ClientFailure(s"Unexpected server response: ${RequestTimeout.code}"))
       }
     }
   }


### PR DESCRIPTION
This PR removes details from client failures and include status code only so that entropy is minimized.

ref: PDP-1642