### PR TITLE
Add Resolver#isSystemError

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/IgluCirceClient.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/IgluCirceClient.scala
@@ -35,7 +35,7 @@ import io.circe.{DecodingFailure, Json}
  * Should provide significant performance boost for the 'check' operation when called frequently.
  */
 final class IgluCirceClient[F[_]] private (
-  resolver: Resolver[F],
+  val resolver: Resolver[F],
   schemaEvaluationCache: SchemaEvaluationCache[F],
   maxJsonDepth: Int
 ) {

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
@@ -206,28 +206,30 @@ final case class Resolver[F[_]](repos: List[Registry], cache: Option[ResolverCac
   }
 
   /**
-   * Checks if the resolution error indicates server unavailability.
+   * Checks if the resolution error indicates a fatal/unrecoverable issue.
    *
    * Returns true when:
-   * - Any custom (non-Iglu Central) repository has a RepoFailure
-   * - All Iglu Central mirrors have a RepoFailure
+   * - Any custom (non-Iglu Central) repository has a RepoFailure or ClientFailure
+   * - All Iglu Central mirrors have a RepoFailure or ClientFailure
    *
    * Returns false otherwise.
    *
-   * If a registry has RepoFailure alongside other errors, assume it is unavailable.
+   * If a registry has a fatal error alongside other errors, assume it is unrecoverable.
    */
   def isUnrecoverable(error: ResolutionError): Boolean = {
     val (igluCentral, custom) = error.value.partition { case (repo, _) =>
       allIgluCentral.contains(repo)
     }
 
-    def hasRepoFailure(history: LookupHistory): Boolean =
-      history.errors.exists(_.isInstanceOf[RegistryError.RepoFailure])
+    def hasFatalError(history: LookupHistory): Boolean =
+      history.errors.exists(e =>
+        e.isInstanceOf[RegistryError.RepoFailure] || e.isInstanceOf[RegistryError.ClientFailure]
+      )
 
-    val customUnavailable = custom.values.exists(hasRepoFailure)
+    val customUnavailable = custom.values.exists(hasFatalError)
 
     val igluCentralUnavailable =
-      igluCentral.nonEmpty && igluCentral.values.forall(hasRepoFailure)
+      igluCentral.nonEmpty && igluCentral.values.forall(hasFatalError)
 
     customUnavailable || igluCentralUnavailable
   }

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
@@ -206,6 +206,33 @@ final case class Resolver[F[_]](repos: List[Registry], cache: Option[ResolverCac
   }
 
   /**
+   * Checks if the resolution error indicates server unavailability.
+   *
+   * Returns true when:
+   * - Any custom (non-Iglu Central) repository has a RepoFailure
+   * - All Iglu Central mirrors have a RepoFailure
+   *
+   * Returns false otherwise.
+   *
+   * If a registry has RepoFailure alongside other errors, assume it is unavailable.
+   */
+  def isUnrecoverable(error: ResolutionError): Boolean = {
+    val (igluCentral, custom) = error.value.partition { case (repo, _) =>
+      allIgluCentral.contains(repo)
+    }
+
+    def hasRepoFailure(history: LookupHistory): Boolean =
+      history.errors.exists(_.isInstanceOf[RegistryError.RepoFailure])
+
+    val customUnavailable = custom.values.exists(hasRepoFailure)
+
+    val igluCentralUnavailable =
+      igluCentral.nonEmpty && igluCentral.values.forall(hasRepoFailure)
+
+    customUnavailable || igluCentralUnavailable
+  }
+
+  /**
    * The variant of lookupSchemasUntilResult that returns the result
    * that isn't wrapped with ResolverResult
    */

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
@@ -209,29 +209,29 @@ final case class Resolver[F[_]](repos: List[Registry], cache: Option[ResolverCac
    * Checks if the resolution error indicates a system/platform issue rather than a data issue.
    *
    * Returns true when:
-   * - Any custom (non-Iglu Central) repository has a RepoFailure or ClientFailure
-   * - All Iglu Central mirrors have a RepoFailure or ClientFailure
+   * - Any custom (non-Iglu Central) repository has ONLY RepoFailure/ClientFailure errors
+   * - All Iglu Central mirrors have ONLY RepoFailure/ClientFailure errors
    *
-   * Returns false otherwise (e.g., NotFound errors indicate missing schema, not system failure).
-   *
-   * If a registry has a fatal error alongside other errors, assume it is a system error.
+   * Returns false otherwise. Notably, if a registry has a NotFound alongside fatal errors,
+   * we consider this NOT a system error because the NotFound confirms the schema doesn't exist.
+   * This prevents crashes when a schema is genuinely missing and the registry later becomes unavailable.
    */
   def isSystemError(error: ResolutionError): Boolean = {
     val (igluCentral, custom) = error.value.partition { case (repo, _) =>
       allIgluCentral.contains(repo)
     }
 
-    def hasFatalError(history: LookupHistory): Boolean =
-      history.errors.exists {
+    def hasOnlyFatalErrors(history: LookupHistory): Boolean =
+      history.errors.nonEmpty && history.errors.forall {
         case _: RegistryError.RepoFailure   => true
         case _: RegistryError.ClientFailure => true
         case RegistryError.NotFound         => false
       }
 
-    val customUnavailable = custom.values.exists(hasFatalError)
+    val customUnavailable = custom.values.exists(hasOnlyFatalErrors)
 
     val igluCentralUnavailable =
-      igluCentral.nonEmpty && igluCentral.values.forall(hasFatalError)
+      igluCentral.nonEmpty && igluCentral.values.forall(hasOnlyFatalErrors)
 
     customUnavailable || igluCentralUnavailable
   }

--- a/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.iglu/client/resolver/Resolver.scala
@@ -206,25 +206,27 @@ final case class Resolver[F[_]](repos: List[Registry], cache: Option[ResolverCac
   }
 
   /**
-   * Checks if the resolution error indicates a fatal/unrecoverable issue.
+   * Checks if the resolution error indicates a system/platform issue rather than a data issue.
    *
    * Returns true when:
    * - Any custom (non-Iglu Central) repository has a RepoFailure or ClientFailure
    * - All Iglu Central mirrors have a RepoFailure or ClientFailure
    *
-   * Returns false otherwise.
+   * Returns false otherwise (e.g., NotFound errors indicate missing schema, not system failure).
    *
-   * If a registry has a fatal error alongside other errors, assume it is unrecoverable.
+   * If a registry has a fatal error alongside other errors, assume it is a system error.
    */
-  def isUnrecoverable(error: ResolutionError): Boolean = {
+  def isSystemError(error: ResolutionError): Boolean = {
     val (igluCentral, custom) = error.value.partition { case (repo, _) =>
       allIgluCentral.contains(repo)
     }
 
     def hasFatalError(history: LookupHistory): Boolean =
-      history.errors.exists(e =>
-        e.isInstanceOf[RegistryError.RepoFailure] || e.isInstanceOf[RegistryError.ClientFailure]
-      )
+      history.errors.exists {
+        case _: RegistryError.RepoFailure   => true
+        case _: RegistryError.ClientFailure => true
+        case RegistryError.NotFound         => false
+      }
 
     val customUnavailable = custom.values.exists(hasFatalError)
 

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
@@ -117,6 +117,9 @@ class ResolverSpec extends Specification with CatsEffect {
     [2 IC mirrors + custom]: one IC RepoFailure, other NotFound, custom NotFound $f7
     [IC + 2 custom]: all NotFound $f8
     [2 IC mirrors + custom]: all NotFound $f9
+    [2 IC mirrors]: both have ClientFailure + NotFound mixed $f10
+    [IC + custom]: custom has RepoFailure + NotFound mixed $f11
+    [IC + custom]: custom has ClientFailure + NotFound mixed $f12
 
   isSystemError should return true when
     [single custom]: RepoFailure $t1
@@ -125,17 +128,14 @@ class ResolverSpec extends Specification with CatsEffect {
     [single IC]: ClientFailure $t4
     [2 IC mirrors]: both have RepoFailure $t5
     [2 IC mirrors]: both have ClientFailure $t6
-    [2 IC mirrors]: both have ClientFailure + NotFound mixed $t7
-    [2 IC mirrors + custom]: custom has RepoFailure $t8
-    [2 IC mirrors + custom]: custom has ClientFailure $t9
-    [2 IC mirrors + custom]: both IC mirrors have mixed fatal errors $t10
-    [2 IC mirrors + custom]: custom has RepoFailure + ClientFailure mixed $t11
-    [IC + custom]: custom has RepoFailure + NotFound mixed $t12
-    [IC + custom]: custom has ClientFailure + NotFound mixed $t13
-    [IC + 2 custom]: one custom has RepoFailure $t14
-    [IC + 2 custom]: one custom has ClientFailure $t15
-    [IC + 2 custom]: both custom have RepoFailure $t16
-    [IC + 2 custom]: both custom have ClientFailure $t17
+    [2 IC mirrors + custom]: custom has RepoFailure $t7
+    [2 IC mirrors + custom]: custom has ClientFailure $t8
+    [2 IC mirrors + custom]: both IC mirrors have mixed fatal errors $t9
+    [2 IC mirrors + custom]: custom has RepoFailure + ClientFailure mixed $t10
+    [IC + 2 custom]: one custom has RepoFailure $t11
+    [IC + 2 custom]: one custom has ClientFailure $t12
+    [IC + 2 custom]: both custom have RepoFailure $t13
+    [IC + 2 custom]: both custom have ClientFailure $t14
   """
 
   import ResolverSpec._
@@ -1041,8 +1041,8 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isSystemError(resolutionError) should beTrue
   }
 
-  // t7: [2 IC mirrors]: both have ClientFailure + NotFound mixed
-  def t7 = {
+  // f10: [2 IC mirrors]: both have ClientFailure + NotFound mixed
+  def f10 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
     val resolutionError = ResolutionError(
@@ -1059,11 +1059,55 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isSystemError(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
-  // t8: [2 IC mirrors + custom]: custom has RepoFailure
-  def t8 = {
+  // f11: [IC + custom]: custom has RepoFailure + NotFound mixed
+  def f11 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Timeout"), RegistryError.NotFound),
+          2,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isSystemError(resolutionError) should beFalse
+  }
+
+  // f12: [IC + custom]: custom has ClientFailure + NotFound mixed
+  def f12 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Forbidden"), RegistryError.NotFound),
+          2,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isSystemError(resolutionError) should beFalse
+  }
+
+  // === TRUE CASES (t1-t14) ===
+
+  // t7: [2 IC mirrors + custom]: custom has RepoFailure
+  def t7 = {
     val resolver: Resolver[Id] =
       Resolver
         .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
@@ -1089,8 +1133,8 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isSystemError(resolutionError) should beTrue
   }
 
-  // t9: [2 IC mirrors + custom]: custom has ClientFailure
-  def t9 = {
+  // t8: [2 IC mirrors + custom]: custom has ClientFailure
+  def t8 = {
     val resolver: Resolver[Id] =
       Resolver
         .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
@@ -1116,44 +1160,38 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isSystemError(resolutionError) should beTrue
   }
 
-  // t10: [2 IC mirrors + custom]: both IC mirrors have mixed fatal errors
+  // t9: [2 IC mirrors + custom]: both IC mirrors have mixed fatal errors (RepoFailure + ClientFailure, no NotFound)
+  def t9 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Timeout"), RegistryError.ClientFailure("Forbidden")),
+          2,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Connection reset"), RegistryError.ClientFailure("Unauthorized")),
+          2,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+
+    resolver.isSystemError(resolutionError) should beTrue
+  }
+
+  // t10: [2 IC mirrors + custom]: custom has RepoFailure + ClientFailure mixed (no NotFound)
   def t10 = {
     val resolver: Resolver[Id] =
       Resolver
         .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
 
-    def mkError(centralErrors: Set[RegistryError], mirrorErrors: Set[RegistryError]) =
-      ResolutionError(
-        SortedMap(
-          SpecHelpers.IgluCentral.config.name -> LookupHistory(centralErrors, 2, Instant.now()),
-          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
-            mirrorErrors,
-            2,
-            Instant.now()
-          ),
-          Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
-        )
-      )
-
-    val repoFailure   = RegistryError.RepoFailure("Timeout")
-    val clientFailure = RegistryError.ClientFailure("Forbidden")
-    val notFound      = RegistryError.NotFound
-
-    resolver.isSystemError(
-      mkError(Set(repoFailure, clientFailure), Set(repoFailure, notFound))
-    ) should beTrue
-    resolver.isSystemError(
-      mkError(Set(repoFailure, clientFailure, notFound), Set(repoFailure, clientFailure, notFound))
-    ) should beTrue
-  }
-
-  // t11: [2 IC mirrors + custom]: custom has RepoFailure + ClientFailure mixed
-  def t11 = {
-    val resolver: Resolver[Id] =
-      Resolver
-        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
-
-    def mkError(errors: Set[RegistryError]) = ResolutionError(
+    val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
           Set(RegistryError.NotFound),
@@ -1165,62 +1203,19 @@ class ResolverSpec extends Specification with CatsEffect {
           1,
           Instant.now()
         ),
-        Repos.custom.config.name -> LookupHistory(errors, 2, Instant.now())
-      )
-    )
-
-    val repoFailure   = RegistryError.RepoFailure("Timeout")
-    val clientFailure = RegistryError.ClientFailure("Forbidden")
-    val notFound      = RegistryError.NotFound
-
-    resolver.isSystemError(mkError(Set(repoFailure, clientFailure))) should beTrue
-    resolver.isSystemError(mkError(Set(repoFailure, clientFailure, notFound))) should beTrue
-  }
-
-  // t12: [IC + custom]: custom has RepoFailure + NotFound mixed
-  def t12 = {
-    val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
-    val resolutionError = ResolutionError(
-      SortedMap(
-        SpecHelpers.IgluCentral.config.name -> LookupHistory(
-          Set(RegistryError.NotFound),
-          1,
-          Instant.now()
-        ),
         Repos.custom.config.name -> LookupHistory(
-          Set(RegistryError.RepoFailure("Timeout"), RegistryError.NotFound),
+          Set(RegistryError.RepoFailure("Timeout"), RegistryError.ClientFailure("Forbidden")),
           2,
           Instant.now()
         )
       )
     )
+
     resolver.isSystemError(resolutionError) should beTrue
   }
 
-  // t13: [IC + custom]: custom has ClientFailure + NotFound mixed
-  def t13 = {
-    val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
-    val resolutionError = ResolutionError(
-      SortedMap(
-        SpecHelpers.IgluCentral.config.name -> LookupHistory(
-          Set(RegistryError.NotFound),
-          1,
-          Instant.now()
-        ),
-        Repos.custom.config.name -> LookupHistory(
-          Set(RegistryError.ClientFailure("Forbidden"), RegistryError.NotFound),
-          2,
-          Instant.now()
-        )
-      )
-    )
-    resolver.isSystemError(resolutionError) should beTrue
-  }
-
-  // t14: [IC + 2 custom]: one custom has RepoFailure
-  def t14 = {
+  // t11: [IC + 2 custom]: one custom has RepoFailure
+  def t11 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
     val resolutionError = ResolutionError(
@@ -1241,8 +1236,8 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isSystemError(resolutionError) should beTrue
   }
 
-  // t15: [IC + 2 custom]: one custom has ClientFailure
-  def t15 = {
+  // t12: [IC + 2 custom]: one custom has ClientFailure
+  def t12 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
     val resolutionError = ResolutionError(
@@ -1263,8 +1258,8 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isSystemError(resolutionError) should beTrue
   }
 
-  // t16: [IC + 2 custom]: both custom have RepoFailure
-  def t16 = {
+  // t13: [IC + 2 custom]: both custom have RepoFailure
+  def t13 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
     val resolutionError = ResolutionError(
@@ -1289,8 +1284,8 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isSystemError(resolutionError) should beTrue
   }
 
-  // t17: [IC + 2 custom]: both custom have ClientFailure
-  def t17 = {
+  // t14: [IC + 2 custom]: both custom have ClientFailure
+  def t14 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
     val resolutionError = ResolutionError(

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
@@ -1174,7 +1174,10 @@ class ResolverSpec extends Specification with CatsEffect {
           Instant.now()
         ),
         SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
-          Set(RegistryError.RepoFailure("Connection reset"), RegistryError.ClientFailure("Unauthorized")),
+          Set(
+            RegistryError.RepoFailure("Connection reset"),
+            RegistryError.ClientFailure("Unauthorized")
+          ),
           2,
           Instant.now()
         ),

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
@@ -63,6 +63,12 @@ object ResolverSpec {
         Registry.HttpConnection(URI.create("http://iglu.acme.com"), None)
       )
 
+    val custom2: Registry =
+      Registry.Http(
+        Registry.Config("Iglu Custom Repo 2", 10, List("com.example")),
+        Registry.HttpConnection(URI.create("http://iglu.example.com"), None)
+      )
+
     val httpRep =
       Registry.Http(
         Registry.Config("Mock Repo", 1, List("com.snowplowanalytics.iglu-test")),
@@ -100,6 +106,27 @@ class ResolverSpec extends Specification with CatsEffect {
     return false if there is just one custom repo that returns a RepoFailure $e22
     return true if there is just one custom repo that returns a ClientFailure $e23
     return true if one Iglu Central repo returns 2 errors and the other one returns one error and one NotFound $e24
+
+  isUnrecoverable should return false when
+    all repos return NotFound $e25
+    custom repo healthy, one Iglu Central mirror unhealthy, other mirror healthy $e26
+    one Iglu Central mirror unhealthy, other healthy (no custom repo) $e27
+    custom repo returns ClientFailure $e28
+    Iglu Central mirrors return ClientFailure (no custom repo) $e29
+    just one custom repo returns NotFound $e30
+    just one custom repo returns ClientFailure $e31
+    Iglu Central mirrors have only non-RepoFailure errors $e32
+    multiple custom repos all healthy $e33
+
+  isUnrecoverable should return true when
+    custom repo unhealthy, Iglu Central mirrors healthy $e34
+    all Iglu Central mirrors unhealthy (no custom repo) $e35
+    just one custom repo unhealthy $e36
+    custom repo has mixed errors including unhealthy $e37
+    custom repo has RepoFailure with other error types $e38
+    all Iglu Central mirrors unhealthy with mixed errors $e39
+    multiple custom repos, one unhealthy $e40
+    multiple custom repos, all unhealthy $e41
   """
 
   import ResolverSpec._
@@ -732,5 +759,400 @@ class ResolverSpec extends Specification with CatsEffect {
     )
 
     resolver.isNotFound(resolutionError) should beTrue
+  }
+
+  def e25 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e26 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Problem")),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e27 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Problem")),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e28 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("402")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e29 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("403 Forbidden")),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("401 Unauthorized")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e30 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e31 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("401")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e32 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    def mkError(centralErrors: Set[RegistryError], mirrorErrors: Set[RegistryError]) =
+      ResolutionError(
+        SortedMap(
+          SpecHelpers.IgluCentral.config.name -> LookupHistory(centralErrors, 2, Instant.now()),
+          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+            mirrorErrors,
+            2,
+            Instant.now()
+          ),
+          Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+        )
+      )
+
+    val clientFailure = RegistryError.ClientFailure("Forbidden")
+    val notFound      = RegistryError.NotFound
+
+    resolver.isUnrecoverable(
+      mkError(Set(clientFailure, notFound), Set(clientFailure, notFound))
+    ) should beFalse
+    resolver.isUnrecoverable(mkError(Set(clientFailure), Set(clientFailure))) should beFalse
+    resolver.isUnrecoverable(mkError(Set(notFound), Set(clientFailure))) should beFalse
+  }
+
+  def e33 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name  -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
+        Repos.custom2.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  def e34 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Something went wrong")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  def e35 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Problem")),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Network issue")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  def e36 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Boom")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  def e37 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Timeout"), RegistryError.NotFound),
+          2,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  def e38 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    def mkError(errors: Set[RegistryError]) = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(errors, 2, Instant.now())
+      )
+    )
+
+    val repoFailure   = RegistryError.RepoFailure("Timeout")
+    val clientFailure = RegistryError.ClientFailure("Forbidden")
+    val notFound      = RegistryError.NotFound
+
+    resolver.isUnrecoverable(mkError(Set(repoFailure, clientFailure))) should beTrue
+    resolver.isUnrecoverable(mkError(Set(repoFailure, clientFailure, notFound))) should beTrue
+  }
+
+  def e39 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    def mkError(centralErrors: Set[RegistryError], mirrorErrors: Set[RegistryError]) =
+      ResolutionError(
+        SortedMap(
+          SpecHelpers.IgluCentral.config.name -> LookupHistory(centralErrors, 2, Instant.now()),
+          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+            mirrorErrors,
+            2,
+            Instant.now()
+          ),
+          Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+        )
+      )
+
+    val repoFailure   = RegistryError.RepoFailure("Timeout")
+    val clientFailure = RegistryError.ClientFailure("Forbidden")
+    val notFound      = RegistryError.NotFound
+
+    resolver.isUnrecoverable(
+      mkError(Set(repoFailure, clientFailure), Set(repoFailure, notFound))
+    ) should beTrue
+    resolver.isUnrecoverable(
+      mkError(Set(repoFailure, clientFailure, notFound), Set(repoFailure, clientFailure, notFound))
+    ) should beTrue
+  }
+
+  def e40 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
+        Repos.custom2.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Unavailable")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  def e41 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
+
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Unavailable")),
+          1,
+          Instant.now()
+        ),
+        Repos.custom2.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Also unavailable")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+
+    resolver.isUnrecoverable(resolutionError) should beTrue
   }
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
@@ -1126,7 +1126,11 @@ class ResolverSpec extends Specification with CatsEffect {
       ResolutionError(
         SortedMap(
           SpecHelpers.IgluCentral.config.name -> LookupHistory(centralErrors, 2, Instant.now()),
-          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(mirrorErrors, 2, Instant.now()),
+          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+            mirrorErrors,
+            2,
+            Instant.now()
+          ),
           Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
         )
       )
@@ -1248,7 +1252,7 @@ class ResolverSpec extends Specification with CatsEffect {
           1,
           Instant.now()
         ),
-        Repos.custom.config.name  -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
         Repos.custom2.config.name -> LookupHistory(
           Set(RegistryError.ClientFailure("Forbidden")),
           1,

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
@@ -107,7 +107,7 @@ class ResolverSpec extends Specification with CatsEffect {
     return true if there is just one custom repo that returns a ClientFailure $e23
     return true if one Iglu Central repo returns 2 errors and the other one returns one error and one NotFound $e24
 
-  isUnrecoverable should return false when
+  isSystemError should return false when
     [single custom]: NotFound $f1
     [single IC]: NotFound $f2
     [2 custom]: all NotFound $f3
@@ -118,7 +118,7 @@ class ResolverSpec extends Specification with CatsEffect {
     [IC + 2 custom]: all NotFound $f8
     [2 IC mirrors + custom]: all NotFound $f9
 
-  isUnrecoverable should return true when
+  isSystemError should return true when
     [single custom]: RepoFailure $t1
     [single custom]: ClientFailure $t2
     [single IC]: RepoFailure $t3
@@ -780,7 +780,7 @@ class ResolverSpec extends Specification with CatsEffect {
         Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f2: [single IC]: NotFound
@@ -795,7 +795,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f3: [2 custom]: all NotFound
@@ -807,7 +807,7 @@ class ResolverSpec extends Specification with CatsEffect {
         Repos.custom2.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f4: [2 IC mirrors]: one RepoFailure, other NotFound
@@ -828,7 +828,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f5: [2 IC mirrors]: one ClientFailure, other NotFound
@@ -849,7 +849,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f6: [2 IC mirrors]: one has RepoFailure + NotFound mixed, other NotFound
@@ -870,7 +870,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f7: [2 IC mirrors + custom]: one IC RepoFailure, other NotFound, custom NotFound
@@ -893,7 +893,7 @@ class ResolverSpec extends Specification with CatsEffect {
         Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f8: [IC + 2 custom]: all NotFound
@@ -911,7 +911,7 @@ class ResolverSpec extends Specification with CatsEffect {
         Repos.custom2.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // f9: [2 IC mirrors + custom]: all NotFound
@@ -934,7 +934,7 @@ class ResolverSpec extends Specification with CatsEffect {
         Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isSystemError(resolutionError) should beFalse
   }
 
   // === TRUE CASES (t1-t17) ===
@@ -951,7 +951,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t2: [single custom]: ClientFailure
@@ -966,7 +966,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t3: [single IC]: RepoFailure
@@ -981,7 +981,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t4: [single IC]: ClientFailure
@@ -996,7 +996,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t5: [2 IC mirrors]: both have RepoFailure
@@ -1017,7 +1017,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t6: [2 IC mirrors]: both have ClientFailure
@@ -1038,7 +1038,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t7: [2 IC mirrors]: both have ClientFailure + NotFound mixed
@@ -1059,7 +1059,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t8: [2 IC mirrors + custom]: custom has RepoFailure
@@ -1086,7 +1086,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t9: [2 IC mirrors + custom]: custom has ClientFailure
@@ -1113,7 +1113,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t10: [2 IC mirrors + custom]: both IC mirrors have mixed fatal errors
@@ -1139,10 +1139,10 @@ class ResolverSpec extends Specification with CatsEffect {
     val clientFailure = RegistryError.ClientFailure("Forbidden")
     val notFound      = RegistryError.NotFound
 
-    resolver.isUnrecoverable(
+    resolver.isSystemError(
       mkError(Set(repoFailure, clientFailure), Set(repoFailure, notFound))
     ) should beTrue
-    resolver.isUnrecoverable(
+    resolver.isSystemError(
       mkError(Set(repoFailure, clientFailure, notFound), Set(repoFailure, clientFailure, notFound))
     ) should beTrue
   }
@@ -1173,8 +1173,8 @@ class ResolverSpec extends Specification with CatsEffect {
     val clientFailure = RegistryError.ClientFailure("Forbidden")
     val notFound      = RegistryError.NotFound
 
-    resolver.isUnrecoverable(mkError(Set(repoFailure, clientFailure))) should beTrue
-    resolver.isUnrecoverable(mkError(Set(repoFailure, clientFailure, notFound))) should beTrue
+    resolver.isSystemError(mkError(Set(repoFailure, clientFailure))) should beTrue
+    resolver.isSystemError(mkError(Set(repoFailure, clientFailure, notFound))) should beTrue
   }
 
   // t12: [IC + custom]: custom has RepoFailure + NotFound mixed
@@ -1195,7 +1195,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t13: [IC + custom]: custom has ClientFailure + NotFound mixed
@@ -1216,7 +1216,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t14: [IC + 2 custom]: one custom has RepoFailure
@@ -1238,7 +1238,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t15: [IC + 2 custom]: one custom has ClientFailure
@@ -1260,7 +1260,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t16: [IC + 2 custom]: both custom have RepoFailure
@@ -1286,7 +1286,7 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 
   // t17: [IC + 2 custom]: both custom have ClientFailure
@@ -1312,6 +1312,6 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-    resolver.isUnrecoverable(resolutionError) should beTrue
+    resolver.isSystemError(resolutionError) should beTrue
   }
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/resolver/ResolverSpec.scala
@@ -108,25 +108,34 @@ class ResolverSpec extends Specification with CatsEffect {
     return true if one Iglu Central repo returns 2 errors and the other one returns one error and one NotFound $e24
 
   isUnrecoverable should return false when
-    all repos return NotFound $e25
-    custom repo healthy, one Iglu Central mirror unhealthy, other mirror healthy $e26
-    one Iglu Central mirror unhealthy, other healthy (no custom repo) $e27
-    custom repo returns ClientFailure $e28
-    Iglu Central mirrors return ClientFailure (no custom repo) $e29
-    just one custom repo returns NotFound $e30
-    just one custom repo returns ClientFailure $e31
-    Iglu Central mirrors have only non-RepoFailure errors $e32
-    multiple custom repos all healthy $e33
+    [single custom]: NotFound $f1
+    [single IC]: NotFound $f2
+    [2 custom]: all NotFound $f3
+    [2 IC mirrors]: one RepoFailure, other NotFound $f4
+    [2 IC mirrors]: one ClientFailure, other NotFound $f5
+    [2 IC mirrors]: one has RepoFailure + NotFound mixed, other NotFound $f6
+    [2 IC mirrors + custom]: one IC RepoFailure, other NotFound, custom NotFound $f7
+    [IC + 2 custom]: all NotFound $f8
+    [2 IC mirrors + custom]: all NotFound $f9
 
   isUnrecoverable should return true when
-    custom repo unhealthy, Iglu Central mirrors healthy $e34
-    all Iglu Central mirrors unhealthy (no custom repo) $e35
-    just one custom repo unhealthy $e36
-    custom repo has mixed errors including unhealthy $e37
-    custom repo has RepoFailure with other error types $e38
-    all Iglu Central mirrors unhealthy with mixed errors $e39
-    multiple custom repos, one unhealthy $e40
-    multiple custom repos, all unhealthy $e41
+    [single custom]: RepoFailure $t1
+    [single custom]: ClientFailure $t2
+    [single IC]: RepoFailure $t3
+    [single IC]: ClientFailure $t4
+    [2 IC mirrors]: both have RepoFailure $t5
+    [2 IC mirrors]: both have ClientFailure $t6
+    [2 IC mirrors]: both have ClientFailure + NotFound mixed $t7
+    [2 IC mirrors + custom]: custom has RepoFailure $t8
+    [2 IC mirrors + custom]: custom has ClientFailure $t9
+    [2 IC mirrors + custom]: both IC mirrors have mixed fatal errors $t10
+    [2 IC mirrors + custom]: custom has RepoFailure + ClientFailure mixed $t11
+    [IC + custom]: custom has RepoFailure + NotFound mixed $t12
+    [IC + custom]: custom has ClientFailure + NotFound mixed $t13
+    [IC + 2 custom]: one custom has RepoFailure $t14
+    [IC + 2 custom]: one custom has ClientFailure $t15
+    [IC + 2 custom]: both custom have RepoFailure $t16
+    [IC + 2 custom]: both custom have ClientFailure $t17
   """
 
   import ResolverSpec._
@@ -761,58 +770,50 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isNotFound(resolutionError) should beTrue
   }
 
-  def e25 = {
-    val resolver: Resolver[Id] =
-      Resolver
-        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+  // === FALSE CASES (f1-f9) ===
 
+  // f1: [single custom]: NotFound
+  def f1 = {
+    val resolver: Resolver[Id] = Resolver.init[Id](0, None, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  // f2: [single IC]: NotFound
+  def f2 = {
+    val resolver: Resolver[Id] = Resolver.init[Id](0, None, SpecHelpers.IgluCentral)
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
           Set(RegistryError.NotFound),
           1,
           Instant.now()
-        ),
-        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
-          Set(RegistryError.NotFound),
-          1,
-          Instant.now()
-        ),
-        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+        )
       )
     )
-
     resolver.isUnrecoverable(resolutionError) should beFalse
   }
 
-  def e26 = {
-    val resolver: Resolver[Id] =
-      Resolver
-        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
-
+  // f3: [2 custom]: all NotFound
+  def f3 = {
+    val resolver: Resolver[Id] = Resolver.init[Id](0, None, Repos.custom, Repos.custom2)
     val resolutionError = ResolutionError(
       SortedMap(
-        SpecHelpers.IgluCentral.config.name -> LookupHistory(
-          Set(RegistryError.RepoFailure("Problem")),
-          1,
-          Instant.now()
-        ),
-        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
-          Set(RegistryError.NotFound),
-          1,
-          Instant.now()
-        ),
-        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+        Repos.custom.config.name  -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
+        Repos.custom2.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
       )
     )
-
     resolver.isUnrecoverable(resolutionError) should beFalse
   }
 
-  def e27 = {
+  // f4: [2 IC mirrors]: one RepoFailure, other NotFound
+  def f4 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
-
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
@@ -827,15 +828,97 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-
     resolver.isUnrecoverable(resolutionError) should beFalse
   }
 
-  def e28 = {
+  // f5: [2 IC mirrors]: one ClientFailure, other NotFound
+  def f5 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Forbidden")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  // f6: [2 IC mirrors]: one has RepoFailure + NotFound mixed, other NotFound
+  def f6 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Timeout"), RegistryError.NotFound),
+          2,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  // f7: [2 IC mirrors + custom]: one IC RepoFailure, other NotFound, custom NotFound
+  def f7 = {
     val resolver: Resolver[Id] =
       Resolver
         .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Problem")),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
 
+  // f8: [IC + 2 custom]: all NotFound
+  def f8 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name  -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
+        Repos.custom2.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  // f9: [2 IC mirrors + custom]: all NotFound
+  def f9 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
@@ -848,21 +931,99 @@ class ResolverSpec extends Specification with CatsEffect {
           1,
           Instant.now()
         ),
+        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beFalse
+  }
+
+  // === TRUE CASES (t1-t17) ===
+
+  // t1: [single custom]: RepoFailure
+  def t1 = {
+    val resolver: Resolver[Id] = Resolver.init[Id](0, None, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
         Repos.custom.config.name -> LookupHistory(
-          Set(RegistryError.ClientFailure("402")),
+          Set(RegistryError.RepoFailure("Boom")),
           1,
           Instant.now()
         )
       )
     )
-
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isUnrecoverable(resolutionError) should beTrue
   }
 
-  def e29 = {
+  // t2: [single custom]: ClientFailure
+  def t2 = {
+    val resolver: Resolver[Id] = Resolver.init[Id](0, None, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("401")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  // t3: [single IC]: RepoFailure
+  def t3 = {
+    val resolver: Resolver[Id] = Resolver.init[Id](0, None, SpecHelpers.IgluCentral)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Connection refused")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  // t4: [single IC]: ClientFailure
+  def t4 = {
+    val resolver: Resolver[Id] = Resolver.init[Id](0, None, SpecHelpers.IgluCentral)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Forbidden")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  // t5: [2 IC mirrors]: both have RepoFailure
+  def t5 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Problem")),
+          1,
+          Instant.now()
+        ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Network issue")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
 
+  // t6: [2 IC mirrors]: both have ClientFailure
+  def t6 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
@@ -877,92 +1038,35 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isUnrecoverable(resolutionError) should beTrue
   }
 
-  def e30 = {
+  // t7: [2 IC mirrors]: both have ClientFailure + NotFound mixed
+  def t7 = {
     val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, Repos.custom)
-
-    val resolutionError = ResolutionError(
-      SortedMap(
-        Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
-      )
-    )
-
-    resolver.isUnrecoverable(resolutionError) should beFalse
-  }
-
-  def e31 = {
-    val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, Repos.custom)
-
-    val resolutionError = ResolutionError(
-      SortedMap(
-        Repos.custom.config.name -> LookupHistory(
-          Set(RegistryError.ClientFailure("401")),
-          1,
-          Instant.now()
-        )
-      )
-    )
-
-    resolver.isUnrecoverable(resolutionError) should beFalse
-  }
-
-  def e32 = {
-    val resolver: Resolver[Id] =
-      Resolver
-        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
-
-    def mkError(centralErrors: Set[RegistryError], mirrorErrors: Set[RegistryError]) =
-      ResolutionError(
-        SortedMap(
-          SpecHelpers.IgluCentral.config.name -> LookupHistory(centralErrors, 2, Instant.now()),
-          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
-            mirrorErrors,
-            2,
-            Instant.now()
-          ),
-          Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
-        )
-      )
-
-    val clientFailure = RegistryError.ClientFailure("Forbidden")
-    val notFound      = RegistryError.NotFound
-
-    resolver.isUnrecoverable(
-      mkError(Set(clientFailure, notFound), Set(clientFailure, notFound))
-    ) should beFalse
-    resolver.isUnrecoverable(mkError(Set(clientFailure), Set(clientFailure))) should beFalse
-    resolver.isUnrecoverable(mkError(Set(notFound), Set(clientFailure))) should beFalse
-  }
-
-  def e33 = {
-    val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
-
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
-          Set(RegistryError.NotFound),
-          1,
+          Set(RegistryError.ClientFailure("Forbidden"), RegistryError.NotFound),
+          2,
           Instant.now()
         ),
-        Repos.custom.config.name  -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
-        Repos.custom2.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Unauthorized"), RegistryError.NotFound),
+          2,
+          Instant.now()
+        )
       )
     )
-
-    resolver.isUnrecoverable(resolutionError) should beFalse
+    resolver.isUnrecoverable(resolutionError) should beTrue
   }
 
-  def e34 = {
+  // t8: [2 IC mirrors + custom]: custom has RepoFailure
+  def t8 = {
     val resolver: Resolver[Id] =
       Resolver
         .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
-
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
@@ -982,53 +1086,14 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-
     resolver.isUnrecoverable(resolutionError) should beTrue
   }
 
-  def e35 = {
+  // t9: [2 IC mirrors + custom]: custom has ClientFailure
+  def t9 = {
     val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror)
-
-    val resolutionError = ResolutionError(
-      SortedMap(
-        SpecHelpers.IgluCentral.config.name -> LookupHistory(
-          Set(RegistryError.RepoFailure("Problem")),
-          1,
-          Instant.now()
-        ),
-        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
-          Set(RegistryError.RepoFailure("Network issue")),
-          1,
-          Instant.now()
-        )
-      )
-    )
-
-    resolver.isUnrecoverable(resolutionError) should beTrue
-  }
-
-  def e36 = {
-    val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, Repos.custom)
-
-    val resolutionError = ResolutionError(
-      SortedMap(
-        Repos.custom.config.name -> LookupHistory(
-          Set(RegistryError.RepoFailure("Boom")),
-          1,
-          Instant.now()
-        )
-      )
-    )
-
-    resolver.isUnrecoverable(resolutionError) should beTrue
-  }
-
-  def e37 = {
-    val resolver: Resolver[Id] =
-      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
-
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
@@ -1036,18 +1101,50 @@ class ResolverSpec extends Specification with CatsEffect {
           1,
           Instant.now()
         ),
+        SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
         Repos.custom.config.name -> LookupHistory(
-          Set(RegistryError.RepoFailure("Timeout"), RegistryError.NotFound),
-          2,
+          Set(RegistryError.ClientFailure("402")),
+          1,
           Instant.now()
         )
       )
     )
-
     resolver.isUnrecoverable(resolutionError) should beTrue
   }
 
-  def e38 = {
+  // t10: [2 IC mirrors + custom]: both IC mirrors have mixed fatal errors
+  def t10 = {
+    val resolver: Resolver[Id] =
+      Resolver
+        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
+
+    def mkError(centralErrors: Set[RegistryError], mirrorErrors: Set[RegistryError]) =
+      ResolutionError(
+        SortedMap(
+          SpecHelpers.IgluCentral.config.name -> LookupHistory(centralErrors, 2, Instant.now()),
+          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(mirrorErrors, 2, Instant.now()),
+          Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+        )
+      )
+
+    val repoFailure   = RegistryError.RepoFailure("Timeout")
+    val clientFailure = RegistryError.ClientFailure("Forbidden")
+    val notFound      = RegistryError.NotFound
+
+    resolver.isUnrecoverable(
+      mkError(Set(repoFailure, clientFailure), Set(repoFailure, notFound))
+    ) should beTrue
+    resolver.isUnrecoverable(
+      mkError(Set(repoFailure, clientFailure, notFound), Set(repoFailure, clientFailure, notFound))
+    ) should beTrue
+  }
+
+  // t11: [2 IC mirrors + custom]: custom has RepoFailure + ClientFailure mixed
+  def t11 = {
     val resolver: Resolver[Id] =
       Resolver
         .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
@@ -1076,40 +1173,52 @@ class ResolverSpec extends Specification with CatsEffect {
     resolver.isUnrecoverable(mkError(Set(repoFailure, clientFailure, notFound))) should beTrue
   }
 
-  def e39 = {
+  // t12: [IC + custom]: custom has RepoFailure + NotFound mixed
+  def t12 = {
     val resolver: Resolver[Id] =
-      Resolver
-        .init[Id](0, None, SpecHelpers.IgluCentral, SpecHelpers.IgluCentralMirror, Repos.custom)
-
-    def mkError(centralErrors: Set[RegistryError], mirrorErrors: Set[RegistryError]) =
-      ResolutionError(
-        SortedMap(
-          SpecHelpers.IgluCentral.config.name -> LookupHistory(centralErrors, 2, Instant.now()),
-          SpecHelpers.IgluCentralMirror.config.name -> LookupHistory(
-            mirrorErrors,
-            2,
-            Instant.now()
-          ),
-          Repos.custom.config.name -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now())
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.RepoFailure("Timeout"), RegistryError.NotFound),
+          2,
+          Instant.now()
         )
       )
-
-    val repoFailure   = RegistryError.RepoFailure("Timeout")
-    val clientFailure = RegistryError.ClientFailure("Forbidden")
-    val notFound      = RegistryError.NotFound
-
-    resolver.isUnrecoverable(
-      mkError(Set(repoFailure, clientFailure), Set(repoFailure, notFound))
-    ) should beTrue
-    resolver.isUnrecoverable(
-      mkError(Set(repoFailure, clientFailure, notFound), Set(repoFailure, clientFailure, notFound))
-    ) should beTrue
+    )
+    resolver.isUnrecoverable(resolutionError) should beTrue
   }
 
-  def e40 = {
+  // t13: [IC + custom]: custom has ClientFailure + NotFound mixed
+  def t13 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Forbidden"), RegistryError.NotFound),
+          2,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
+
+  // t14: [IC + 2 custom]: one custom has RepoFailure
+  def t14 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
-
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
@@ -1125,14 +1234,35 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
-
     resolver.isUnrecoverable(resolutionError) should beTrue
   }
 
-  def e41 = {
+  // t15: [IC + 2 custom]: one custom has ClientFailure
+  def t15 = {
     val resolver: Resolver[Id] =
       Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name  -> LookupHistory(Set(RegistryError.NotFound), 1, Instant.now()),
+        Repos.custom2.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Forbidden")),
+          1,
+          Instant.now()
+        )
+      )
+    )
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
 
+  // t16: [IC + 2 custom]: both custom have RepoFailure
+  def t16 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
     val resolutionError = ResolutionError(
       SortedMap(
         SpecHelpers.IgluCentral.config.name -> LookupHistory(
@@ -1152,7 +1282,32 @@ class ResolverSpec extends Specification with CatsEffect {
         )
       )
     )
+    resolver.isUnrecoverable(resolutionError) should beTrue
+  }
 
+  // t17: [IC + 2 custom]: both custom have ClientFailure
+  def t17 = {
+    val resolver: Resolver[Id] =
+      Resolver.init[Id](0, None, SpecHelpers.IgluCentral, Repos.custom, Repos.custom2)
+    val resolutionError = ResolutionError(
+      SortedMap(
+        SpecHelpers.IgluCentral.config.name -> LookupHistory(
+          Set(RegistryError.NotFound),
+          1,
+          Instant.now()
+        ),
+        Repos.custom.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Forbidden")),
+          1,
+          Instant.now()
+        ),
+        Repos.custom2.config.name -> LookupHistory(
+          Set(RegistryError.ClientFailure("Unauthorized")),
+          1,
+          Instant.now()
+        )
+      )
+    )
     resolver.isUnrecoverable(resolutionError) should beTrue
   }
 }


### PR DESCRIPTION
Add Resolver#isSystemError to allow users to determine if a resolution error is caused by Iglu server unavailability.

Returns true when:
- At least one custom Iglu Server is *unhealthy*
- All Iglu Central mirrors are *unhealthy*

`*unhealthy*`: errors of a LookupHistory can be either
- full of RepoFailure: easy to consider this registry as unhealthy
- a mix of RepoFailure along with NotFound and/or ClientFailure: I considered the registry unavailable, since errors is a Set[RegistryError] which is unordered
- no RepoFailure at all: can't consider registry as unhealthy

Returns false when:
- At least one Iglu Central mirror is healthy
- All custom Iglu Servers are healthy

ref: https://snplow.atlassian.net/browse/PDP-2318