### PR TITLE
Add test for multiple validation error determinism

### DIFF
--- a/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/validator/RawValidationSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.iglu.client/validator/RawValidationSpec.scala
@@ -40,6 +40,7 @@ class RawValidationSpec extends Specification with DataTables {
   validate null in [array, null] type $e8
   invalidate stringly integer with integer type $e9
   validate integer with number type $e10
+  required + additionalProperties returns errors in deterministic order $e11
   """
 
   val simpleSchemaResult: Json =
@@ -244,5 +245,39 @@ class RawValidationSpec extends Specification with DataTables {
     val schema = json"""{ "type": "number" }"""
     val input  = json"""5"""
     CirceValidator.validate(input, schema) must beRight
+  }
+
+  def e11 = {
+    val schema = json"""
+      {
+        "$$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "type": "object",
+        "properties": {
+          "sku": { "type": "string" },
+          "quantity": { "type": "number" }
+        },
+        "required": ["sku", "quantity"],
+        "additionalProperties": false
+      }
+      """
+    val input = json"""{"skuu": "pedals", "quantity": 2}"""
+    val expected = ValidatorError.InvalidData(
+      NonEmptyList.of(
+        ValidatorReport(
+          "$.skuu: is not defined in the schema and the schema does not allow additional properties",
+          Some("$"),
+          List("skuu"),
+          Some("additionalProperties")
+        ),
+        ValidatorReport(
+          "$.sku: is missing but it is required",
+          Some("$"),
+          List("sku"),
+          Some("required")
+        )
+      )
+    )
+
+    CirceValidator.validate(input, schema) must beLeft(expected)
   }
 }


### PR DESCRIPTION
This test was added to investigate whether iglu-scala-client 4.1.0 broke an implicit error ordering guarantee after upgrading json-schema-validator from 1.0.76 to 1.5.8.

Findings:
- The error order changed: 1.0.76 returned "required" before "additionalProperties", while 1.5.8 returns "additionalProperties" before "required"
- The existing doubleError test (e2) only tested errors of the same type ("type"), which happened to maintain consistent path-based ordering. Missing such a case is the reason why we didn't see this as we upgrade the version.

JSON or JSON Schema doesn't have ordering, so I can't *blame* json-schema-validator for not doing a major bump here.

Either we
- implement ordering guarantee in iglu-scala-client for peace of mind in downstream users
- have order-free interpretation of validation result in downstream users OR order validation result 